### PR TITLE
Add OOPath comparative benchmarks

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/AbstractOOPathComparisonBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/AbstractOOPathComparisonBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.drools.benchmarks.common.AbstractBenchmark;
+import org.drools.benchmarks.common.ProviderException;
+import org.drools.benchmarks.oopath.model.Child;
+import org.drools.benchmarks.oopath.model.Man;
+import org.drools.benchmarks.oopath.model.Toy;
+import org.drools.benchmarks.oopath.model.Woman;
+import org.drools.core.common.InternalFactHandle;
+import org.kie.api.runtime.KieSession;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 40000)
+@Measurement(iterations = 10000)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public abstract class AbstractOOPathComparisonBenchmark extends AbstractBenchmark {
+
+    protected static final String MODEL_PACKAGE_IMPORT = "import org.drools.benchmarks.oopath.model.*;";
+
+    @Param({"10"})
+    protected int numberOfParentFacts;
+
+    protected List<Man> parentFacts;
+    protected List<Child> factsToBeModified;
+    protected List<String> globalList;
+
+    public abstract void setupKieBase();
+
+    @Setup(Level.Iteration)
+    @Override
+    public void setup() throws ProviderException {
+        createKieSession();
+        globalList = new ArrayList<>();
+        kieSession.setGlobal("list", globalList);
+        prepareFacts();
+    }
+
+    private void prepareFacts() {
+        parentFacts = generateModel(numberOfParentFacts);
+        factsToBeModified = getChildToBeModified(parentFacts);
+    }
+
+    private static List<Man> generateModel(final int nr) {
+        final List<Man> model = new ArrayList<>();
+        for (int i = 0; i < nr; i++) {
+            final Man man = new Man("m" + i, 40);
+            model.add(man);
+            final Woman woman = new Woman("w" + i, 35);
+            man.setWife(woman);
+            woman.setHusband(man.getName());
+
+            final Child childA = new Child("cA" + i, 12);
+            woman.addChild(childA);
+            childA.setMother(woman.getName());
+            final Child childB = new Child("cB" + i, 10);
+            woman.addChild(childB);
+            childB.setMother(woman.getName());
+
+            final Toy toyA = new Toy("tA" + i);
+            toyA.setOwner(childA.getName());
+            childA.addToy(toyA);
+            final Toy toyB = new Toy("tB" + i);
+            toyB.setOwner(childA.getName());
+            childA.addToy(toyB);
+            final Toy toyC = new Toy("tC" + i);
+            toyC.setOwner(childB.getName());
+            childB.addToy(toyC);
+        }
+        return model;
+    }
+
+    private static List<Child> getChildToBeModified(final List<Man> model) {
+        final List<Child> toBeModified = new ArrayList<>();
+        for (final Man man : model) {
+            for (final Child child : man.getWife().getChildren()) {
+                if (child.getAge() == 10) {
+                    toBeModified.add(child);
+                }
+            }
+        }
+        return toBeModified;
+    }
+
+    protected static List<InternalFactHandle> insertModel(final KieSession ksession, final List<Man> model) {
+        final List<InternalFactHandle> fhs = new ArrayList<>();
+        for (final Man man : model) {
+            fhs.add((InternalFactHandle)ksession.insert(man));
+        }
+        return fhs;
+    }
+
+    protected static List<InternalFactHandle> insertFullModel(final KieSession ksession, final List<Man> model) {
+        final List<InternalFactHandle> toBeModified = new ArrayList<>();
+        for (final Man man : model) {
+            ksession.insert(man);
+            ksession.insert(man.getWife());
+            for (final Child child : man.getWife().getChildren()) {
+                final InternalFactHandle fh = (InternalFactHandle)ksession.insert(child);
+                if (child.getAge() == 10) {
+                    toBeModified.add(fh);
+                }
+                for (final Toy toy : child.getToys()) {
+                    ksession.insert(toy);
+                }
+            }
+        }
+        return toBeModified;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonFromVariationInsertBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonFromVariationInsertBenchmark.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class OOPathComparisonFromVariationInsertBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $man: Man( $wife: wife )\n" +
+                "    $child: Child( age > 10 ) from $wife.children\n" +
+                "    $toy: Toy() from $child.toys\n" +
+                "then\n" +
+                "    list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    @Benchmark
+    public int testInsert(final Blackhole eater) {
+        eater.consume(insertModel(kieSession, parentFacts));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonFromVariationUpdateBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonFromVariationUpdateBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.drools.core.common.InternalFactHandle;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+
+public class OOPathComparisonFromVariationUpdateBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $man: Man( $wife: wife )\n" +
+                "    $child: Child( age > 10 ) from $wife.children\n" +
+                "    $toy: Toy() from $child.toys\n" +
+                "then\n" +
+                "    list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    private List<InternalFactHandle> factHandles;
+
+    @Setup(Level.Iteration)
+    public void insertFacts() {
+        factHandles = insertModel(kieSession, parentFacts);
+        kieSession.fireAllRules();
+        globalList.clear();
+    }
+
+    @Benchmark
+    public int testUpdate() {
+        factsToBeModified.forEach(child -> child.setAge(11));
+        factHandles.forEach(factHandle -> kieSession.update(factHandle, factHandle.getObject()));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonOOpathVariationInsertBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonOOpathVariationInsertBenchmark.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class OOPathComparisonOOpathVariationInsertBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Man( $toy: /wife/children{age > 10}/toys )\n" +
+                "then\n" +
+                "  list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    @Benchmark
+    public int testInsert(final Blackhole eater) {
+        eater.consume(insertModel(kieSession, parentFacts));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonOOpathVariationUpdateBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonOOpathVariationUpdateBenchmark.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+
+public class OOPathComparisonOOpathVariationUpdateBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "  Man( $toy: /wife/children{age > 10}/toys )\n" +
+                "then\n" +
+                "  list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    @Setup(Level.Iteration)
+    public void insertFacts() {
+        insertModel(kieSession, parentFacts);
+        kieSession.fireAllRules();
+        globalList.clear();
+    }
+
+    @Benchmark
+    public int testUpdate() {
+        factsToBeModified.forEach(child -> child.setAge(11));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonRelationalVariationInsertBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonRelationalVariationInsertBenchmark.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class OOPathComparisonRelationalVariationInsertBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $man : Man()\n" +
+                "    $wife : Woman( husband == $man.name )\n" +
+                "    $child : Child( mother == $wife.name, age > 10 )\n" +
+                "    $toy : Toy( owner == $child.name )\n" +
+                "then\n" +
+                "    list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    @Benchmark
+    public int testInsert(final Blackhole eater) {
+        eater.consume(insertFullModel(kieSession, parentFacts));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonRelationalVariationUpdateBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/OOPathComparisonRelationalVariationUpdateBenchmark.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath;
+
+import java.util.List;
+import org.drools.core.common.InternalFactHandle;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+
+public class OOPathComparisonRelationalVariationUpdateBenchmark extends AbstractOOPathComparisonBenchmark {
+
+    @Setup
+    @Override
+    public void setupKieBase() {
+        final String drl = MODEL_PACKAGE_IMPORT + "\n" +
+                "global java.util.List list\n" +
+                "\n" +
+                "rule R when\n" +
+                "    $man : Man()\n" +
+                "    $wife : Woman( husband == $man.name )\n" +
+                "    $child : Child( mother == $wife.name, age > 10 )\n" +
+                "    $toy : Toy( owner == $child.name )\n" +
+                "then\n" +
+                "    list.add( $toy.getName() );\n" +
+                "end\n";
+        createKieBaseFromDrl(drl);
+    }
+
+    private List<InternalFactHandle> factHandles;
+
+    @Setup(Level.Iteration)
+    public void insertFacts() {
+        factHandles = insertFullModel(kieSession, parentFacts);
+        kieSession.fireAllRules();
+        globalList.clear();
+    }
+
+    @Benchmark
+    public int testUpdate() {
+        factsToBeModified.forEach(child -> child.setAge(11));
+        factHandles.forEach(factHandle -> kieSession.update(factHandle, factHandle.getObject()));
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Adult.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Adult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+import java.util.List;
+import org.drools.core.phreak.ReactiveList;
+
+public class Adult extends Person {
+
+    private final List<Child> children = new ReactiveList<Child>();
+
+    public Adult(String name, int age) {
+        super(name, age);
+    }
+
+    public List<Child> getChildren() {
+        return children;
+    }
+
+    public void addChild(Child child) {
+        children.add(child);
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/BodyMeasurement.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/BodyMeasurement.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+public enum BodyMeasurement {
+    RIGHT_FOREARM, LEFT_FOREARM, RIGHT_UPPERARM, LEFT_UPPERARM,
+    CHEST, WAIST, HIPS, RIGHT_THIGH, LEFT_HIGH, RIGHT_CALF, LEFT_CALF
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Child.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Child.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+import java.util.List;
+import org.drools.core.phreak.ReactiveList;
+
+public class Child extends Person {
+
+    private String mother;
+
+    private final List<Toy> toys = new ReactiveList<Toy>();
+
+    public Child(String name, int age) {
+        super(name, age);
+    }
+
+    public List<Toy> getToys() {
+        return toys;
+    }
+
+    public void addToy(Toy toy) {
+        toys.add(toy);
+    }
+
+    public String getMother() {
+        return mother;
+    }
+
+    public void setMother(String mother) {
+        this.mother = mother;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Disease.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Disease.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+
+import org.drools.core.phreak.AbstractReactiveObject;
+
+public class Disease extends AbstractReactiveObject {
+
+    private String name;
+
+    public Disease (final String name) {
+        this.name = name;
+    }
+
+    public void setName(final String name ) {
+        this.name = name;
+        notifyModification();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return ("Disease: " + name);
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Man.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Man.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+public class Man extends Adult {
+
+    private Woman wife;
+
+    public Man(String name, int age) {
+        super(name, age);
+    }
+
+    public Woman getWife() {
+        return wife;
+    }
+
+    public void setWife(Woman wife) {
+        this.wife = wife;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Person.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Person.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.drools.core.phreak.AbstractReactiveObject;
+import org.drools.core.phreak.ReactiveSet;
+
+public abstract class Person extends AbstractReactiveObject {
+
+    private final String name;
+    private int age;
+
+    private final Set<Disease> diseases = new ReactiveSet<>();
+
+    private final Map<BodyMeasurement, Integer> bodyMeasurementsMap = new HashMap<>();
+
+    public Person(final String name, final int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(final int age) {
+        this.age = age;
+        notifyModification();
+    }
+
+    public Set<Disease> getDiseases() {
+        return  diseases;
+    }
+
+    public void addDisease(final Disease disease) {
+        diseases.add(disease);
+    }
+
+    public Map<BodyMeasurement, Integer> getBodyMeasurementsMap() {
+        return this.bodyMeasurementsMap;
+    }
+
+    public void putBodyMeasurement(final BodyMeasurement bodyMeasurement, final Integer number) {
+        bodyMeasurementsMap.put(bodyMeasurement, number);
+        notifyModification();
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Toy.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Toy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+import org.drools.core.phreak.AbstractReactiveObject;
+
+public class Toy extends AbstractReactiveObject {
+
+    private String name;
+
+    private String owner;
+
+    public Toy(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName( String name ) {
+        this.name = name;
+        notifyModification();
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public String toString() {
+        return "Toy: " + name;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Woman.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/oopath/model/Woman.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.oopath.model;
+
+public class Woman extends Adult {
+
+    private String husband;
+
+    public Woman(String name, int age) {
+        super(name, age);
+    }
+
+    public String getHusband() {
+        return husband;
+    }
+
+    public void setHusband(String husband) {
+        this.husband = husband;
+    }
+}


### PR DESCRIPTION
Add benchmarks that replace class OOPathBenchmarkTest [1] from
Drools repository

I will merge this when reviewed. 

[1] https://github.com/kiegroup/drools/blob/master/drools-compiler/src/test/java/org/drools/compiler/oopath/OOPathBenchmarkTest.java