### PR TITLE
PLANNER-1374: Add Vehicle Routing real world benchmark

### DIFF
--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
@@ -1,0 +1,94 @@
+package org.jboss.qa.brms.performance.realworld.vrp;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.qa.brms.performance.AbstractPlannerBenchmark;
+import org.jboss.qa.brms.performance.calculatecounttermination.HardVRPCalculateCountTermination;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.VehicleRouting;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
+import org.optaplanner.core.config.domain.ScanAnnotatedClassesConfig;
+import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
+import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
+import org.optaplanner.core.config.localsearch.decider.acceptor.AcceptorConfig;
+import org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
+import org.optaplanner.core.config.phase.PhaseConfig;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRoutingSolution> {
+
+    private static final String VEHCILE_ROUTING_DOMAIN_PACKAGE = "org.jboss.qa.brms.performance.examples.vehiclerouting";
+    private static final String VEHCILE_ROUTING_DROOLS_SCORE_RULES_FILE = "org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl";
+
+    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRouting.DataSet dataset;
+
+    @Override
+    public void initSolution() {
+        super.setSolution(new VehicleRouting().loadSolvingProblem(dataset));
+    }
+
+    @Override
+    public void initSolver() {
+        SolverFactory<VehicleRoutingSolution> solverFactory = SolverFactory.createEmpty();
+        SolverConfig config = solverFactory.getSolverConfig();
+
+        ScanAnnotatedClassesConfig scanAnnotatedClassesConfig = new ScanAnnotatedClassesConfig();
+        scanAnnotatedClassesConfig.setPackageIncludeList(Collections.singletonList(VEHCILE_ROUTING_DOMAIN_PACKAGE));
+
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+        scoreDirectorFactoryConfig.setInitializingScoreTrend("ONLY_DOWN");
+        scoreDirectorFactoryConfig.setScoreDrlList(Collections.singletonList(VEHCILE_ROUTING_DROOLS_SCORE_RULES_FILE));
+
+        config.setPhaseConfigList(getPhaseConfigList());
+        config.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
+        config.setTerminationConfig(new TerminationConfig().withTerminationClass(HardVRPCalculateCountTermination.class));
+        config.setScanAnnotatedClassesConfig(scanAnnotatedClassesConfig);
+
+        super.setSolver(solverFactory.buildSolver());
+    }
+
+    @Benchmark
+    public VehicleRoutingSolution benchmark() {
+        return super.benchmark();
+    }
+
+    private List<PhaseConfig> getPhaseConfigList() {
+        ConstructionHeuristicPhaseConfig constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
+        constructionHeuristicPhaseConfig.setConstructionHeuristicType(ConstructionHeuristicType.FIRST_FIT_DECREASING);
+
+        LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
+
+        SubChainChangeMoveSelectorConfig subChainChangeMoveSelectorConfig = new SubChainChangeMoveSelectorConfig();
+        subChainChangeMoveSelectorConfig.setSelectReversingMoveToo(true);
+
+        SubChainSwapMoveSelectorConfig subChainSwapMoveSelectorConfig = new SubChainSwapMoveSelectorConfig();
+        subChainSwapMoveSelectorConfig.setSelectReversingMoveToo(true);
+
+        localSearchPhaseConfig.setMoveSelectorConfig(new UnionMoveSelectorConfig(Arrays.asList(new ChangeMoveSelectorConfig(),
+                                                                                               new SwapMoveSelectorConfig(),
+                                                                                               subChainChangeMoveSelectorConfig,
+                                                                                               subChainSwapMoveSelectorConfig)));
+
+        localSearchPhaseConfig.setAcceptorConfig(new AcceptorConfig().withLateAcceptanceSize(200));
+
+        LocalSearchForagerConfig foragerConfig = new LocalSearchForagerConfig();
+        foragerConfig.setAcceptedCountLimit(1);
+
+        localSearchPhaseConfig.setForagerConfig(foragerConfig);
+
+        return Arrays.asList(constructionHeuristicPhaseConfig, localSearchPhaseConfig);
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
@@ -14,6 +14,7 @@ import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
 import org.optaplanner.core.config.domain.ScanAnnotatedClassesConfig;
+import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
@@ -31,6 +32,8 @@ public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRou
 
     private static final String VEHCILE_ROUTING_DOMAIN_PACKAGE = "org.jboss.qa.brms.performance.examples.vehiclerouting";
     private static final String VEHCILE_ROUTING_DROOLS_SCORE_RULES_FILE = "org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl";
+    private static final int FORAGER_CONFIG_ACCEPTED_COUNT_LIMIT = 1;
+    private static final int ACCEPTOR_CONFIG_LATE_ACCEPTANCE_SIZE = 200;
 
     @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
     private VehicleRouting.DataSet dataset;
@@ -77,17 +80,18 @@ public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRou
         SubChainSwapMoveSelectorConfig subChainSwapMoveSelectorConfig = new SubChainSwapMoveSelectorConfig();
         subChainSwapMoveSelectorConfig.setSelectReversingMoveToo(true);
 
-        localSearchPhaseConfig.setMoveSelectorConfig(new UnionMoveSelectorConfig(Arrays.asList(new ChangeMoveSelectorConfig(),
-                                                                                               new SwapMoveSelectorConfig(),
-                                                                                               subChainChangeMoveSelectorConfig,
-                                                                                               subChainSwapMoveSelectorConfig)));
-
-        localSearchPhaseConfig.setAcceptorConfig(new AcceptorConfig().withLateAcceptanceSize(200));
+        List<MoveSelectorConfig> moveSelectorConfigList = Arrays.asList(new ChangeMoveSelectorConfig(),
+                                                                        new SwapMoveSelectorConfig(),
+                                                                        subChainChangeMoveSelectorConfig,
+                                                                        subChainSwapMoveSelectorConfig);
+        UnionMoveSelectorConfig selectorConfig = new UnionMoveSelectorConfig(moveSelectorConfigList);
 
         LocalSearchForagerConfig foragerConfig = new LocalSearchForagerConfig();
-        foragerConfig.setAcceptedCountLimit(1);
+        foragerConfig.setAcceptedCountLimit(FORAGER_CONFIG_ACCEPTED_COUNT_LIMIT);
 
         localSearchPhaseConfig.setForagerConfig(foragerConfig);
+        localSearchPhaseConfig.setMoveSelectorConfig(selectorConfig);
+        localSearchPhaseConfig.setAcceptorConfig(new AcceptorConfig().withLateAcceptanceSize(ACCEPTOR_CONFIG_LATE_ACCEPTANCE_SIZE));
 
         return Arrays.asList(constructionHeuristicPhaseConfig, localSearchPhaseConfig);
     }

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.optaplanner.examples.vehiclerouting.solver;
+package org.jboss.qa.brms.performance.examples.vrp.solver;
     dialect "java"
 
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder;

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/vrp/solver/vehicleRoutingScoreRules.drl
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.vehiclerouting.solver;
+    dialect "java"
+
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScoreHolder;
+
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.Depot;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.location.Location;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.Vehicle;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.VehicleRoutingSolution;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.Customer;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.timewindowed.TimeWindowedDepot;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.timewindowed.TimeWindowedVehicleRoutingSolution;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.timewindowed.TimeWindowedCustomer
+import org.jboss.qa.brms.performance.examples.vehiclerouting.domain.Vehicle;
+
+global HardSoftLongScoreHolder scoreHolder;
+
+// ############################################################################
+// Hard constraints
+// ############################################################################
+
+rule "vehicleCapacity"
+    when
+        $vehicle : Vehicle($capacity : capacity)
+        accumulate(
+            Customer(
+                vehicle == $vehicle,
+                $demand : demand);
+            $demandTotal : sum($demand);
+            $demandTotal > $capacity
+        )
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, $capacity - $demandTotal);
+end
+
+// ############################################################################
+// Soft constraints
+// ############################################################################
+
+rule "distanceToPreviousStandstill"
+    when
+        $customer : Customer(previousStandstill != null, $distanceFromPreviousStandstill : distanceFromPreviousStandstill)
+    then
+        scoreHolder.addSoftConstraintMatch(kcontext, - $distanceFromPreviousStandstill);
+end
+
+rule "distanceFromLastCustomerToDepot"
+    when
+        $customer : Customer(previousStandstill != null)
+        not Customer(previousStandstill == $customer)
+    then
+        Vehicle vehicle = $customer.getVehicle();
+        scoreHolder.addSoftConstraintMatch(kcontext, - $customer.getDistanceTo(vehicle));
+end
+
+
+// ############################################################################
+// TimeWindowed: additional hard constraints
+// ############################################################################
+
+rule "arrivalAfterDueTime"
+    when
+        TimeWindowedCustomer(dueTime < arrivalTime, $dueTime : dueTime, $arrivalTime : arrivalTime)
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, $dueTime - $arrivalTime.longValue());
+end
+
+// Score constraint arrivalAfterDueTimeAtDepot is a built-in hard constraint in VehicleRoutingImporter


### PR DESCRIPTION
Tweaked solver config to scan annotated classes from VRP domain, unlike [original](https://github.com/Fonifan/optaplanner/blob/master/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml) (from optaplanner-examples ) solver config, which has hardcoded classes.
