### PR TITLE
DROOLS-3412: Added a process runtime to the benchmark which registers…

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/session/sessionpool/DisposeSessionBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/session/sessionpool/DisposeSessionBenchmark.java
@@ -16,6 +16,7 @@
 
 package org.drools.benchmarks.session.sessionpool;
 
+import java.lang.reflect.Field;
 import java.util.Collection;
 
 import org.kie.api.runtime.KieSession;
@@ -45,6 +46,7 @@ public class DisposeSessionBenchmark extends AbstractSessionsPoolBenchmark {
     @Setup(Level.Iteration)
     public void setupKieSessions(final Blackhole eater) {
         kieSession = usePool ? sessionsPool.newKieSession() : kieContainer.newKieSession();
+        kieSession.getProcessInstance(0); // Force the creation of a process instance
         exerciseSession(kieSession, factsForSession, eater);
     }
 


### PR DESCRIPTION
This PR allows to reproduce DROOLS-3412.  The smallest change to reproduce this issue seems to be to create a process runtime which registers event listeners as done by JBPMs ProcessRuntimeImpl. Of course the performance impact is more severe for JBPMs ProcessRuntimeImpl as it actually implements the event listeners while the dummy process runtime I've added really just registers listeners which do nothing. 

Refer also to:

- https://github.com/kiegroup/drools/pull/2186
- https://github.com/kiegroup/drools/pull/2187