### PR TITLE
Align persistence dependencies with kie-parent

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests/pom.xml
+++ b/jbpm-benchmarks/jbpm-performance-tests/pom.xml
@@ -158,8 +158,8 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>


### PR DESCRIPTION
This was missing Hibernate alignment that was done as part of main repos. 