### PR TITLE
Conference scheduling generator fix

### DIFF
--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
@@ -28,7 +28,7 @@ public class ConferenceSchedulingBenchmark extends AbstractPlannerBenchmark<Conf
     private static final String CONFERENCE_SCHEDULING_DROOLS_SCORE_RULES_FILE =
             "org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingScoreRules.drl";
 
-    @Param({"TALKS_36_TIMESLOTS_12_ROOMS_5", "TALKS_108_TIMESLOTS_18_ROOMS_10", "TALKS_216_TIMESLOTS_18_ROOMS_20"})
+    @Param({"DAY_2_ROOM_5", "DAY_3_ROOM_10", "DAY_3_ROOM_20"})
     private ConferenceScheduling.DataSet dataSet;
 
     @Override

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceScheduling.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceScheduling.java
@@ -34,59 +34,44 @@ public class ConferenceScheduling extends AbstractExample<ConferenceSolution> {
     private static final String PATH_TO_DRL_FILE =
             "/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingScoreRules.drl";
 
-    private static final String PATH_TO_SOLVE_CONFIG =
+    private static final String PATH_TO_SOLVER_CONFIG =
             "/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
 
     public enum DataSet {
-        TALKS_36_TIMESLOTS_12_ROOMS_5("TIME_12;ROOM_5;SPEAKER_26;TALK_36"),
-        TALKS_108_TIMESLOTS_18_ROOMS_10("TIME_18;ROOM_10;SPEAKER_74;TALK_108"),
-        TALKS_216_TIMESLOTS_18_ROOMS_20("TIME_18;ROOM_20;SPEAKER_146;TALK_216");
+        DAY_2_ROOM_5("DAY_2;ROOM_5"),   //12 time slots, 36 talks, 24 speakers
+        DAY_3_ROOM_10("DAY_3;ROOM_10"), //18 time slots, 108 talks, 72 speakers
+        DAY_3_ROOM_20("DAY_3;ROOM_20"); //18 time slots, 216 talks, 144 speakers
 
-        private int timeslotListSize;
+        private int dayListSize;
         private int roomListSize;
-        private int speakerListSize;
-        private int talkListSize;
 
         DataSet(String generatorParameters) {
-            Stream<String> parameters = Arrays.stream(generatorParameters.split(";", 4));
+            Stream<String> parameters = Arrays.stream(generatorParameters.split(";", 2));
 
             parameters.forEach(s -> {
-                if (s.startsWith("TIME")) {
-                    timeslotListSize = Integer.parseInt(s.split("_")[1]);
-                } else if (s.startsWith("ROOM")) {
+                if (s.startsWith("DAY")) {
+                    dayListSize = Integer.parseInt(s.split("_")[1]);
+                } else {
                     roomListSize = Integer.parseInt(s.split("_")[1]);
-                } else if (s.startsWith("SPEAKER")) {
-                    speakerListSize = Integer.parseInt(s.split("_")[1]);
-                } else if (s.startsWith("TALK")) {
-                    talkListSize = Integer.parseInt(s.split("_")[1]);
                 }
             });
 
             parameters.close();
         }
 
-        public int getTimeslotListSize() {
-            return timeslotListSize;
+        public int getDayListSize() {
+            return dayListSize;
         }
 
         public int getRoomListSize() {
             return roomListSize;
         }
 
-        public int getSpeakerListSize() {
-            return speakerListSize;
-        }
-
-        public int getTalkListSize() {
-            return talkListSize;
-        }
     }
 
     public ConferenceSolution loadSolvingProblem(ConferenceScheduling.DataSet dataset) {
-        return new ConferenceSchedulingGenerator().createConferenceSolution(dataset.timeslotListSize,
-                                                                            dataset.roomListSize,
-                                                                            dataset.speakerListSize,
-                                                                            dataset.talkListSize);
+        return new ConferenceSchedulingGenerator().buildConferenceSolution(dataset.dayListSize,
+                                                                           dataset.roomListSize);
     }
 
     @Override
@@ -96,7 +81,7 @@ public class ConferenceScheduling extends AbstractExample<ConferenceSolution> {
 
     @Override
     public SolverFactory<ConferenceSolution> getDefaultSolverFactory() {
-        return SolverFactory.createFromXmlInputStream(this.getClass().getResourceAsStream(PATH_TO_SOLVE_CONFIG));
+        return SolverFactory.createFromXmlInputStream(this.getClass().getResourceAsStream(PATH_TO_SOLVER_CONFIG));
     }
 
     @Override

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/persistence/ConferenceSchedulingGenerator.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/persistence/ConferenceSchedulingGenerator.java
@@ -16,6 +16,7 @@
 
 package org.jboss.qa.brms.performance.examples.conferencescheduling.persistence;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -204,7 +205,21 @@ public class ConferenceSchedulingGenerator {
     protected int labTalkCount;
     protected Random random;
 
-    public ConferenceSolution createConferenceSolution(int timeslotListSize, int roomListSize,
+    public ConferenceSolution buildConferenceSolution(int dayListSize, int roomListSize) {
+        int labTimeslotCount = (int) timeslotOptions.stream()
+                .filter(pair -> Duration.between(pair.getLeft(), pair.getRight()).toMinutes() >= 120).count();
+        int labRoomCount = roomListSize / 5;
+        labTalkCount = (dayListSize * labTimeslotCount) * labRoomCount;
+
+        int timeslotListSize = dayListSize * timeslotOptions.size();
+        int talkListSize = (dayListSize * (timeslotOptions.size() - labTimeslotCount)) * (roomListSize - labRoomCount)
+                + labTalkCount;
+        int speakerListSize = talkListSize * 2 / 3;
+
+        return createConferenceSolution(timeslotListSize, roomListSize, speakerListSize, talkListSize);
+    }
+
+    private ConferenceSolution createConferenceSolution(int timeslotListSize, int roomListSize,
                                                        int speakerListSize, int talkListSize) {
         random = new Random(37);
         ConferenceSolution solution = new ConferenceSolution();


### PR DESCRIPTION
Initial error was me missing an important layer of abstraction and directly creating `ConferenceSolution` via `createConferenceSolution` method. This method uses field `labTalkCount`, however doesn't initialize it in any way.
The method `writeConferenceSolution` (renamed to `buildConferenceSolution`) initializes needed field,  but was marked `private`, unlike `createConferenceSolution`, which was marked `public` as if it was API...

### Fixes :
* Used an additional layer of abstraction provided by `buildConferenceSolution` method.
* Renamed `PATH_TO_SOLVER_CONFIG` (typo).
* Adjusted new data set generating parameters, so they would be equal with previous ones.
* Renamed data sets accordingly.