### PR TITLE
[PLANNER-1483] Add ChangeMove microbenchmark

### DIFF
--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
@@ -3,22 +3,16 @@ package org.jboss.qa.brms.performance.micro;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.SampleTime)
-//@Fork(value = 1)
-//@Warmup(iterations = 150000)
-//@Measurement(iterations = 10000)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public abstract class AbstractPlannerMoveMicroBenchmark<Solution> {
 

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
@@ -3,16 +3,23 @@ package org.jboss.qa.brms.performance.micro;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 @State(Scope.Thread)
-@BenchmarkMode(Mode.SampleTime)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 5)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public abstract class AbstractPlannerMoveMicroBenchmark<Solution> {
 
@@ -35,11 +42,18 @@ public abstract class AbstractPlannerMoveMicroBenchmark<Solution> {
         this.move = move;
     }
 
-    @Setup
-    public abstract void initScoreDirector();
+    protected abstract void initScoreDirector();
 
-    @Setup
-    public abstract void initMove();
+    protected abstract void initMove();
+
+    protected abstract void initEntities();
+
+    @Setup(Level.Invocation)
+    public void initBenchmark() {
+        initEntities();
+        initMove();
+        initScoreDirector();
+    }
 
     public Move<Solution> benchmarkDoMove() {
         return getMove().doMove(getScoreDirector());

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/AbstractPlannerMoveMicroBenchmark.java
@@ -1,0 +1,57 @@
+package org.jboss.qa.brms.performance.micro;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.SampleTime)
+//@Fork(value = 1)
+//@Warmup(iterations = 150000)
+//@Measurement(iterations = 10000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public abstract class AbstractPlannerMoveMicroBenchmark<Solution> {
+
+    private Move<Solution> move;
+    private ScoreDirector<Solution> scoreDirector;
+
+    public ScoreDirector<Solution> getScoreDirector() {
+        return scoreDirector;
+    }
+
+    public void setScoreDirector(ScoreDirector<Solution> scoreDirector) {
+        this.scoreDirector = scoreDirector;
+    }
+
+    public Move<Solution> getMove() {
+        return move;
+    }
+
+    public void setMove(Move<Solution> move) {
+        this.move = move;
+    }
+
+    @Setup
+    public abstract void initScoreDirector();
+
+    @Setup
+    public abstract void initMove();
+
+    public Move<Solution> benchmarkDoMove() {
+        return getMove().doMove(getScoreDirector());
+    }
+
+    public Move<Solution> benchmarkRebase() {
+        return getMove().rebase(getScoreDirector());
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
@@ -1,0 +1,78 @@
+package org.jboss.qa.brms.performance.micro.changemove;
+
+import java.util.Collections;
+
+import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudBalance;
+import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudComputer;
+import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudProcess;
+import org.jboss.qa.brms.performance.examples.cloudbalancing.solver.score.CloudBalancingEasyScoreCalculator;
+import org.jboss.qa.brms.performance.micro.AbstractPlannerMoveMicroBenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
+import org.optaplanner.core.impl.score.director.easy.EasyScoreDirector;
+import org.optaplanner.core.impl.score.director.easy.EasyScoreDirectorFactory;
+
+public class ChangeMoveBenchmark extends AbstractPlannerMoveMicroBenchmark<CloudBalance> {
+
+    private CloudComputer cloudComputer = getCloudComputer();
+    private CloudProcess cloudProcess = getCloudProcess();
+    private SolutionDescriptor<CloudBalance> solutionDescriptor = SolutionDescriptor.
+            buildSolutionDescriptor(CloudBalance.class, CloudProcess.class);
+
+    private static CloudComputer getCloudComputer() {
+        CloudComputer cloudComputer = new CloudComputer();
+        cloudComputer.setId(1L);
+        cloudComputer.setCost(200);
+        cloudComputer.setCpuPower(2000);
+        cloudComputer.setNetworkBandwidth(200);
+        cloudComputer.setMemory(200);
+        return cloudComputer;
+    }
+
+    private static CloudProcess getCloudProcess() {
+        CloudProcess cloudProcess = new CloudProcess();
+        cloudProcess.setId(1L);
+        cloudProcess.setRequiredCpuPower(3000);
+        cloudProcess.setRequiredMemory(300);
+        cloudProcess.setRequiredNetworkBandwidth(300);
+        return cloudProcess;
+    }
+
+    @Override
+    public void initMove() {
+        EntityDescriptor<CloudBalance> entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(CloudProcess.class);
+        GenuineVariableDescriptor<CloudBalance> genuineVariableDescriptor = entityDescriptor.getGenuineVariableDescriptor("computer");
+        ChangeMove<CloudBalance> cloudBalanceChangeMove = new ChangeMove<>(cloudProcess, genuineVariableDescriptor, cloudComputer);
+        super.setMove(cloudBalanceChangeMove);
+    }
+
+    @Override
+    public void initScoreDirector() {
+        CloudBalancingEasyScoreCalculator cloudBalancingEasyScoreCalculator = new CloudBalancingEasyScoreCalculator();
+        EasyScoreDirector<CloudBalance> cloudBalanceScoreDirector = new EasyScoreDirector<>
+                (new EasyScoreDirectorFactory<>(solutionDescriptor,
+                                                cloudBalancingEasyScoreCalculator),
+                 true,
+                 true,
+                 cloudBalancingEasyScoreCalculator);
+        CloudBalance workingSolution = new CloudBalance();
+        workingSolution.setComputerList(Collections.singletonList(cloudComputer));
+        workingSolution.setProcessList(Collections.singletonList(cloudProcess));
+        cloudBalanceScoreDirector.setWorkingSolution(workingSolution);
+        super.setScoreDirector(cloudBalanceScoreDirector);
+    }
+
+    @Benchmark
+    public Move<CloudBalance> benchmarkDoMove() {
+        return super.benchmarkDoMove();
+    }
+
+    @Benchmark
+    public Move<CloudBalance> benchmarkRebase() {
+        return super.benchmarkRebase();
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
@@ -19,9 +19,8 @@ import org.optaplanner.core.impl.score.director.easy.EasyScoreDirectorFactory;
 public class ChangeMoveBenchmark extends AbstractPlannerMoveMicroBenchmark<TestdataSolution> {
 
     private TestdataValue testdataValue = new TestdataValue("v1");
-    private TestdataEntity testdataEntity = new TestdataEntity("e1");
-    private SolutionDescriptor<TestdataSolution> solutionDescriptor = SolutionDescriptor.
-            buildSolutionDescriptor(TestdataSolution.class, TestdataEntity.class);
+    private TestdataEntity testdataEntity;
+    private SolutionDescriptor<TestdataSolution> solutionDescriptor;
 
     @Override
     public void initMove() {
@@ -32,6 +31,12 @@ public class ChangeMoveBenchmark extends AbstractPlannerMoveMicroBenchmark<Testd
         ChangeMove<TestdataSolution> testdataSolutionChangeMove =
                 new ChangeMove<>(testdataEntity, genuineVariableDescriptor, testdataValue);
         super.setMove(testdataSolutionChangeMove);
+    }
+
+    @Override
+    protected void initEntities() {
+        testdataEntity = new TestdataEntity("e1");
+        solutionDescriptor = SolutionDescriptor.buildSolutionDescriptor(TestdataSolution.class, TestdataEntity.class);
     }
 
     @Override

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/micro/changemove/ChangeMoveBenchmark.java
@@ -2,11 +2,11 @@ package org.jboss.qa.brms.performance.micro.changemove;
 
 import java.util.Collections;
 
-import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudBalance;
-import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudComputer;
-import org.jboss.qa.brms.performance.examples.cloudbalancing.domain.CloudProcess;
-import org.jboss.qa.brms.performance.examples.cloudbalancing.solver.score.CloudBalancingEasyScoreCalculator;
 import org.jboss.qa.brms.performance.micro.AbstractPlannerMoveMicroBenchmark;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataEntity;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataSolution;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataValue;
+import org.jboss.qa.brms.performance.testdata.solver.score.TestdataEasyScoreCalculator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
@@ -16,63 +16,47 @@ import org.optaplanner.core.impl.heuristic.selector.move.generic.ChangeMove;
 import org.optaplanner.core.impl.score.director.easy.EasyScoreDirector;
 import org.optaplanner.core.impl.score.director.easy.EasyScoreDirectorFactory;
 
-public class ChangeMoveBenchmark extends AbstractPlannerMoveMicroBenchmark<CloudBalance> {
+public class ChangeMoveBenchmark extends AbstractPlannerMoveMicroBenchmark<TestdataSolution> {
 
-    private CloudComputer cloudComputer = getCloudComputer();
-    private CloudProcess cloudProcess = getCloudProcess();
-    private SolutionDescriptor<CloudBalance> solutionDescriptor = SolutionDescriptor.
-            buildSolutionDescriptor(CloudBalance.class, CloudProcess.class);
-
-    private static CloudComputer getCloudComputer() {
-        CloudComputer cloudComputer = new CloudComputer();
-        cloudComputer.setId(1L);
-        cloudComputer.setCost(200);
-        cloudComputer.setCpuPower(2000);
-        cloudComputer.setNetworkBandwidth(200);
-        cloudComputer.setMemory(200);
-        return cloudComputer;
-    }
-
-    private static CloudProcess getCloudProcess() {
-        CloudProcess cloudProcess = new CloudProcess();
-        cloudProcess.setId(1L);
-        cloudProcess.setRequiredCpuPower(3000);
-        cloudProcess.setRequiredMemory(300);
-        cloudProcess.setRequiredNetworkBandwidth(300);
-        return cloudProcess;
-    }
+    private TestdataValue testdataValue = new TestdataValue("v1");
+    private TestdataEntity testdataEntity = new TestdataEntity("e1");
+    private SolutionDescriptor<TestdataSolution> solutionDescriptor = SolutionDescriptor.
+            buildSolutionDescriptor(TestdataSolution.class, TestdataEntity.class);
 
     @Override
     public void initMove() {
-        EntityDescriptor<CloudBalance> entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(CloudProcess.class);
-        GenuineVariableDescriptor<CloudBalance> genuineVariableDescriptor = entityDescriptor.getGenuineVariableDescriptor("computer");
-        ChangeMove<CloudBalance> cloudBalanceChangeMove = new ChangeMove<>(cloudProcess, genuineVariableDescriptor, cloudComputer);
-        super.setMove(cloudBalanceChangeMove);
+        EntityDescriptor<TestdataSolution> entityDescriptor = solutionDescriptor.
+                findEntityDescriptorOrFail(TestdataEntity.class);
+        GenuineVariableDescriptor<TestdataSolution> genuineVariableDescriptor = entityDescriptor.
+                getGenuineVariableDescriptor("value");
+        ChangeMove<TestdataSolution> testdataSolutionChangeMove =
+                new ChangeMove<>(testdataEntity, genuineVariableDescriptor, testdataValue);
+        super.setMove(testdataSolutionChangeMove);
     }
 
     @Override
     public void initScoreDirector() {
-        CloudBalancingEasyScoreCalculator cloudBalancingEasyScoreCalculator = new CloudBalancingEasyScoreCalculator();
-        EasyScoreDirector<CloudBalance> cloudBalanceScoreDirector = new EasyScoreDirector<>
+        TestdataEasyScoreCalculator testdataEasyScoreCalculator = new TestdataEasyScoreCalculator();
+        EasyScoreDirector<TestdataSolution> testdataSolutionEasyScoreDirector = new EasyScoreDirector<>
                 (new EasyScoreDirectorFactory<>(solutionDescriptor,
-                                                cloudBalancingEasyScoreCalculator),
+                                                testdataEasyScoreCalculator),
                  true,
                  true,
-                 cloudBalancingEasyScoreCalculator);
-        CloudBalance workingSolution = new CloudBalance();
-        workingSolution.setComputerList(Collections.singletonList(cloudComputer));
-        workingSolution.setProcessList(Collections.singletonList(cloudProcess));
-        cloudBalanceScoreDirector.setWorkingSolution(workingSolution);
-        super.setScoreDirector(cloudBalanceScoreDirector);
+                 testdataEasyScoreCalculator);
+        TestdataSolution workingSolution = new TestdataSolution();
+        workingSolution.setValueList(Collections.singletonList(testdataValue));
+        workingSolution.setEntityList(Collections.singletonList(testdataEntity));
+        testdataSolutionEasyScoreDirector.setWorkingSolution(workingSolution);
+        super.setScoreDirector(testdataSolutionEasyScoreDirector);
     }
 
     @Benchmark
-    public Move<CloudBalance> benchmarkDoMove() {
+    public Move<TestdataSolution> benchmarkDoMove() {
         return super.benchmarkDoMove();
     }
 
     @Benchmark
-    public Move<CloudBalance> benchmarkRebase() {
+    public Move<TestdataSolution> benchmarkRebase() {
         return super.benchmarkRebase();
     }
 }

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataEntity.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+
+@PlanningEntity
+public class TestdataEntity extends TestdataObject {
+
+    public static EntityDescriptor<TestdataSolution> buildEntityDescriptor() {
+        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        return solutionDescriptor.findEntityDescriptorOrFail(TestdataEntity.class);
+    }
+
+    public static GenuineVariableDescriptor<TestdataSolution> buildVariableDescriptorForValue() {
+        SolutionDescriptor<TestdataSolution> solutionDescriptor = TestdataSolution.buildSolutionDescriptor();
+        EntityDescriptor<TestdataSolution> entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(TestdataEntity.class);
+        return entityDescriptor.getGenuineVariableDescriptor("value");
+    }
+
+    private TestdataValue value;
+
+    public TestdataEntity() {
+    }
+
+    public TestdataEntity(String code) {
+        super(code);
+    }
+
+    public TestdataEntity(String code, TestdataValue value) {
+        this(code);
+        this.value = value;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    public TestdataValue getValue() {
+        return value;
+    }
+
+    public void setValue(TestdataValue value) {
+        this.value = value;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataObject.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataObject.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain;
+
+import org.optaplanner.core.api.domain.lookup.PlanningId;
+import org.jboss.qa.brms.performance.testdata.util.CodeAssertable;
+
+public class TestdataObject implements CodeAssertable {
+
+    @PlanningId
+    protected String code;
+
+    public TestdataObject() {
+    }
+
+    public TestdataObject(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataSolution.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataSolution.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+@PlanningSolution
+public class TestdataSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataSolution.class, TestdataEntity.class);
+    }
+
+    private List<TestdataValue> valueList;
+    private List<TestdataEntity> entityList;
+
+    private SimpleScore score;
+
+    public TestdataSolution() {
+    }
+
+    public TestdataSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<TestdataValue> valueList) {
+        this.valueList = valueList;
+    }
+
+    @PlanningEntityCollectionProperty
+    public List<TestdataEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataValue.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/TestdataValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain;
+
+public class TestdataValue extends TestdataObject {
+
+    public TestdataValue() {
+    }
+
+    public TestdataValue(String code) {
+        super(code);
+    }
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedAnchor.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedAnchor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained;
+
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+public class TestdataChainedAnchor extends TestdataObject implements TestdataChainedObject {
+
+    public TestdataChainedAnchor() {
+    }
+
+    public TestdataChainedAnchor(String code) {
+        super(code);
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedEntity.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableGraphType;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+@PlanningEntity
+public class TestdataChainedEntity extends TestdataObject implements TestdataChainedObject {
+
+    public static EntityDescriptor<TestdataChainedSolution> buildEntityDescriptor() {
+        SolutionDescriptor<TestdataChainedSolution> solutionDescriptor = TestdataChainedSolution.buildSolutionDescriptor();
+        return solutionDescriptor.findEntityDescriptorOrFail(TestdataChainedEntity.class);
+    }
+
+    public static GenuineVariableDescriptor<TestdataChainedSolution> buildVariableDescriptorForChainedObject() {
+        SolutionDescriptor<TestdataChainedSolution> solutionDescriptor = TestdataChainedSolution.buildSolutionDescriptor();
+        EntityDescriptor<TestdataChainedSolution> entityDescriptor = solutionDescriptor.findEntityDescriptorOrFail(TestdataChainedEntity.class);
+        return entityDescriptor.getGenuineVariableDescriptor("chainedObject");
+    }
+
+    private TestdataChainedObject chainedObject;
+
+    public TestdataChainedEntity() {
+    }
+
+    public TestdataChainedEntity(String code) {
+        super(code);
+    }
+
+    public TestdataChainedEntity(String code, TestdataChainedObject chainedObject) {
+        this(code);
+        this.chainedObject = chainedObject;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = {"chainedAnchorRange", "chainedEntityRange"},
+            graphType = PlanningVariableGraphType.CHAINED)
+    public TestdataChainedObject getChainedObject() {
+        return chainedObject;
+    }
+
+    public void setChainedObject(TestdataChainedObject chainedObject) {
+        this.chainedObject = chainedObject;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedObject.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedObject.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained;
+
+public interface TestdataChainedObject {
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedSolution.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/TestdataChainedSolution.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+@PlanningSolution
+public class TestdataChainedSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataChainedSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataChainedSolution.class, TestdataChainedEntity.class);
+    }
+
+    private List<TestdataChainedAnchor> chainedAnchorList;
+    private List<TestdataChainedEntity> chainedEntityList;
+
+    private SimpleScore score;
+
+    public TestdataChainedSolution() {
+    }
+
+    public TestdataChainedSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "chainedAnchorRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataChainedAnchor> getChainedAnchorList() {
+        return chainedAnchorList;
+    }
+
+    public void setChainedAnchorList(List<TestdataChainedAnchor> chainedAnchorList) {
+        this.chainedAnchorList = chainedAnchorList;
+    }
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider(id = "chainedEntityRange")
+    public List<TestdataChainedEntity> getChainedEntityList() {
+        return chainedEntityList;
+    }
+
+    public void setChainedEntityList(List<TestdataChainedEntity> chainedEntityList) {
+        this.chainedEntityList = chainedEntityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedAnchor.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedAnchor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained.rich;
+
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+public class TestdataRichChainedAnchor extends TestdataObject implements TestdataRichChainedObject {
+
+    // Shadow variables
+    private TestdataRichChainedEntity nextEntity;
+
+    public TestdataRichChainedAnchor() {
+    }
+
+    public TestdataRichChainedAnchor(String code) {
+        super(code);
+    }
+
+    @Override
+    public TestdataRichChainedEntity getNextEntity() {
+        return nextEntity;
+    }
+
+    @Override
+    public void setNextEntity(TestdataRichChainedEntity nextEntity) {
+        this.nextEntity = nextEntity;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedEntity.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedEntity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained.rich;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.AnchorShadowVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.api.domain.variable.PlanningVariableGraphType;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+@PlanningEntity
+public class TestdataRichChainedEntity extends TestdataObject implements TestdataRichChainedObject {
+
+    public static EntityDescriptor buildEntityDescriptor() {
+        SolutionDescriptor solutionDescriptor = TestdataRichChainedSolution.buildSolutionDescriptor();
+        return solutionDescriptor.findEntityDescriptorOrFail(TestdataRichChainedEntity.class);
+    }
+
+    private TestdataRichChainedObject chainedObject;
+
+    // Shadow variables
+    private TestdataRichChainedEntity nextEntity;
+    private TestdataRichChainedAnchor anchor;
+
+    public TestdataRichChainedEntity() {
+    }
+
+    public TestdataRichChainedEntity(String code) {
+        super(code);
+    }
+
+    public TestdataRichChainedEntity(String code, TestdataRichChainedObject chainedObject) {
+        this(code);
+        this.chainedObject = chainedObject;
+    }
+
+    @PlanningVariable(valueRangeProviderRefs = {"chainedAnchorRange", "chainedEntityRange"},
+            graphType = PlanningVariableGraphType.CHAINED)
+    public TestdataRichChainedObject getChainedObject() {
+        return chainedObject;
+    }
+
+    public void setChainedObject(TestdataRichChainedObject chainedObject) {
+        this.chainedObject = chainedObject;
+    }
+
+    @Override
+    public TestdataRichChainedEntity getNextEntity() {
+        return nextEntity;
+    }
+
+    @Override
+    public void setNextEntity(TestdataRichChainedEntity nextEntity) {
+        this.nextEntity = nextEntity;
+    }
+
+    @AnchorShadowVariable(sourceVariableName = "chainedObject")
+    public TestdataRichChainedAnchor getAnchor() {
+        return anchor;
+    }
+
+    public void setAnchor(TestdataRichChainedAnchor anchor) {
+        this.anchor = anchor;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedObject.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedObject.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained.rich;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.variable.InverseRelationShadowVariable;
+
+@PlanningEntity
+public interface TestdataRichChainedObject {
+
+    /**
+     * @return sometimes null
+     */
+    @InverseRelationShadowVariable(sourceVariableName = "chainedObject")
+    TestdataRichChainedEntity getNextEntity();
+    void setNextEntity(TestdataRichChainedEntity nextEntity);
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedSolution.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/domain/chained/rich/TestdataRichChainedSolution.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.domain.chained.rich;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.jboss.qa.brms.performance.testdata.domain.TestdataObject;
+
+@PlanningSolution
+public class TestdataRichChainedSolution extends TestdataObject {
+
+    public static SolutionDescriptor<TestdataRichChainedSolution> buildSolutionDescriptor() {
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataRichChainedSolution.class,
+                                                          TestdataRichChainedObject.class, TestdataRichChainedEntity.class);
+    }
+
+    private List<TestdataRichChainedAnchor> chainedAnchorList;
+    private List<TestdataRichChainedEntity> chainedEntityList;
+
+    private SimpleScore score;
+
+    public TestdataRichChainedSolution() {
+    }
+
+    public TestdataRichChainedSolution(String code) {
+        super(code);
+    }
+
+    @ValueRangeProvider(id = "chainedAnchorRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataRichChainedAnchor> getChainedAnchorList() {
+        return chainedAnchorList;
+    }
+
+    public void setChainedAnchorList(List<TestdataRichChainedAnchor> chainedAnchorList) {
+        this.chainedAnchorList = chainedAnchorList;
+    }
+
+    @PlanningEntityCollectionProperty
+    @ValueRangeProvider(id = "chainedEntityRange")
+    public List<TestdataRichChainedEntity> getChainedEntityList() {
+        return chainedEntityList;
+    }
+
+    public void setChainedEntityList(List<TestdataRichChainedEntity> chainedEntityList) {
+        this.chainedEntityList = chainedEntityList;
+    }
+
+    @PlanningScore
+    public SimpleScore getScore() {
+        return score;
+    }
+
+    public void setScore(SimpleScore score) {
+        this.score = score;
+    }
+
+    // ************************************************************************
+    // Complex methods
+    // ************************************************************************
+
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/solver/score/TestdataEasyScoreCalculator.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/solver/score/TestdataEasyScoreCalculator.java
@@ -1,0 +1,25 @@
+package org.jboss.qa.brms.performance.testdata.solver.score;
+
+import org.jboss.qa.brms.performance.testdata.domain.TestdataSolution;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.score.director.easy.EasyScoreCalculator;
+
+public class TestdataEasyScoreCalculator implements EasyScoreCalculator<TestdataSolution> {
+
+    @Override
+    public Score calculateScore(TestdataSolution testdataSolution) {
+        SimpleScore score = SimpleScore.of(0);
+        if (!testdataSolution.getEntityList().isEmpty()) {
+            score.add(SimpleScore.of(1));
+        } else {
+            score.add(SimpleScore.of(-1));
+        }
+        if (!testdataSolution.getValueList().isEmpty()) {
+            score.add(SimpleScore.of(1));
+        } else {
+            score.add(SimpleScore.of(-1));
+        }
+        return score;
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/solver/score/TestdataEasyScoreCalculator.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/solver/score/TestdataEasyScoreCalculator.java
@@ -9,17 +9,6 @@ public class TestdataEasyScoreCalculator implements EasyScoreCalculator<Testdata
 
     @Override
     public Score calculateScore(TestdataSolution testdataSolution) {
-        SimpleScore score = SimpleScore.of(0);
-        if (!testdataSolution.getEntityList().isEmpty()) {
-            score.add(SimpleScore.of(1));
-        } else {
-            score.add(SimpleScore.of(-1));
-        }
-        if (!testdataSolution.getValueList().isEmpty()) {
-            score.add(SimpleScore.of(1));
-        } else {
-            score.add(SimpleScore.of(-1));
-        }
-        return score;
+        return SimpleScore.of(0);
     }
 }

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/util/CodeAssertable.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/testdata/util/CodeAssertable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.qa.brms.performance.testdata.util;
+
+public interface CodeAssertable {
+
+    String getCode();
+
+}


### PR DESCRIPTION
I used `SampleTime` benchmarking mode, because it proved to be **really** stable:
* benchmarking score deviation between different benchmarks was less than 1% 
* benchmarking score error is usually not higher than 2%.

Migrated `testdata*` classes to isolate benchmark from changes in examples.