### PR TITLE
Reintroduce kie-platform-bom

### DIFF
--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -22,14 +22,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- KIE Platform BOM -->
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-parent</artifactId>
-        <type>pom</type>
-        <version>${kie.bom.version}</version>
-        <scope>import</scope>
-      </dependency>
       <!-- Modules -->
       <dependency>
         <groupId>org.kie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
       <dependency>
         <groupId>org.kie</groupId>
-        <artifactId>kie-parent</artifactId>
+        <artifactId>kie-platform-bom</artifactId>
         <version>${kie.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
Revert of f817bb553628cb9ec0795ee608a27161a0f4b745 and deletion of a duplicate declaration in the ` optaplanner-benchmarks` module