### PR TITLE
Use kie-platform-bom again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@
     <dependencies>
       <dependency>
         <groupId>org.kie</groupId>
-        <artifactId>kie-parent</artifactId>
+        <artifactId>kie-platform-bom</artifactId>
         <version>${kie.bom.version}</version>
-        <type>pom</type>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Despite the fact that the script I introduced yesterday correctly replaced the version, tests still fail. The reason is KIE artifacts' versions are not defined in kie-parent anymore, but in kie-platform-bom. We already use it on master branch

This PR introduced kie-platform-bom to 7.26.x branch. Compilation passed locally with bxms nexus and public-pnc nexus group.