### PR TITLE
Remove version parameter from run.sh scripts

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests/run.sh
+++ b/jbpm-benchmarks/jbpm-performance-tests/run.sh
@@ -1,11 +1,6 @@
-#/bin/sh
+#!/bin/sh -x
 
 PARAMS=""
-
-if [ -n "$version" ]
-then
-  PARAMS="$PARAMS -Dversion.org.kie=$version"
-fi
 
 if [ -n "$suite" ]
 then

--- a/jbpm-benchmarks/kieserver-performance-tests/run.sh
+++ b/jbpm-benchmarks/kieserver-performance-tests/run.sh
@@ -1,11 +1,6 @@
-#/bin/sh
+#!/bin/sh -x
 
 PARAMS=""
-
-if [ -n "$version" ]
-then
-  PARAMS="$PARAMS -Dversion.org.kie=$version"
-fi
 
 if [ -n "$suite" ]
 then


### PR DESCRIPTION
After the introduction of the #61 I no longer need to override the `version.org.kie` property. I have already tested it with all perf jobs.