### PR TITLE
DROOLS-4899 supporting benchmark for DMN extended builtin function ...

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/providers/dmn/TriangularNumHardDMNProvider.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/providers/dmn/TriangularNumHardDMNProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.common.providers.dmn;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.drools.benchmarks.common.DMNProvider;
+
+public class TriangularNumHardDMNProvider implements DMNProvider {
+
+    @Override
+    public String getDMN() {
+        return getDMN(1);
+    }
+
+    @Override
+    public String getDMN(int numberOfElements) {
+        final StringBuilder dmnBuilder = new StringBuilder();
+
+        dmnBuilder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        dmnBuilder.append("<definitions id=\"dmn-triangular\" name=\"dmn-triangular\"\n");
+        dmnBuilder.append("             namespace=\"https://github.com/kiegroup/kie-dmn\"\n");
+        dmnBuilder.append("             xmlns=\"http://www.omg.org/spec/DMN/20180521/MODEL/\"\n");
+        dmnBuilder.append("             xmlns:feel=\"http://www.omg.org/spec/DMN/20180521/FEEL/\">\n");
+
+        for (int i = 0; i < numberOfElements; i++) {
+            dmnBuilder.append(getSubDecision(i + 1));
+        }
+        dmnBuilder.append(getMainDecision(numberOfElements));
+
+        dmnBuilder.append("</definitions>");
+
+        return dmnBuilder.toString();
+    }
+
+    private Object getMainDecision(int numberOfElements) {
+        final StringBuilder contextBuilder = new StringBuilder();
+        contextBuilder.append("  <decision id=\"maindecision\" name=\"maindecision\">\n");
+        contextBuilder.append("    <variable name=\"maindecision\" typeRef=\"number\"/>\n");
+        for (int i = 0; i < numberOfElements; i++) {
+            contextBuilder.append("    <informationRequirement><requiredDecision href=\"#decision" + (i + 1) + "\"/></informationRequirement>");
+        }
+        String expr = IntStream.range(1, numberOfElements + 1).mapToObj(x -> "decision" + x).collect(Collectors.joining(" + "));
+        contextBuilder.append("    <literalExpression typeRef=\"number\"><text>" + expr + "</text></literalExpression>\n");
+        contextBuilder.append("  </decision>\n");
+        return contextBuilder.toString();
+    }
+
+    private String getSubDecision(final int index) {
+        final StringBuilder contextBuilder = new StringBuilder();
+        contextBuilder.append("  <decision id=\"decision" + index + "\" name=\"decision" + index + "\">\n");
+        contextBuilder.append("    <variable name=\"decision" + index + "\" typeRef=\"number\"/>\n");
+        contextBuilder.append("    <literalExpression typeRef=\"number\"><text>" + index + "</text></literalExpression>\n");
+        contextBuilder.append("  </decision>\n");
+        return contextBuilder.toString();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/runtime/DMNEvaluateTriangularNumHardBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/runtime/DMNEvaluateTriangularNumHardBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.dmn.runtime;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.drools.benchmarks.common.AbstractBenchmark;
+import org.drools.benchmarks.common.DMNProvider;
+import org.drools.benchmarks.common.ProviderException;
+import org.drools.benchmarks.common.providers.dmn.TriangularNumHardDMNProvider;
+import org.drools.benchmarks.dmn.util.DMNUtil;
+import org.kie.api.KieServices;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 100)
+@Measurement(iterations = 50)
+public class DMNEvaluateTriangularNumHardBenchmark extends AbstractBenchmark {
+
+    @Param({"20", "50"})
+    private int numberOfDecisionsWithContext;
+
+    private Resource dmnResource;
+    private DMNRuntime dmnRuntime;
+    private DMNModel dmnModel;
+    private DMNContext dmnContext;
+
+    @Setup
+    public void setupResource() {
+        final DMNProvider dmnProvider = new TriangularNumHardDMNProvider();
+        dmnResource = KieServices.get().getResources()
+                .newReaderResource(new StringReader(dmnProvider.getDMN(numberOfDecisionsWithContext)))
+                .setResourceType(ResourceType.DMN)
+                .setSourcePath("dmnFile.dmn");
+    }
+
+    @Setup(Level.Iteration)
+    @Override
+    public void setup() throws ProviderException {
+        try {
+            dmnRuntime = DMNUtil.getDMNRuntimeWithResources(false, dmnResource);
+            dmnModel = dmnRuntime.getModel("https://github.com/kiegroup/kie-dmn", "dmn-triangular");
+            dmnContext = dmnRuntime.newContext();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Benchmark
+    public DMNResult evaluateContext() {
+        return dmnRuntime.evaluateAll(dmnModel, dmnContext);
+    }
+}


### PR DESCRIPTION
... for runtime

/cc @etirelli @baldimir @jiripetrlik @hellowdan 

This benchmark is to demonstrate the changes in: https://github.com/kiegroup/drools/pull/2704/files#diff-f8b55628e7a6cbf19d6b7b3793d3d9c7R69

has no performance impact, as expected:

```
BEFORE

Benchmark                                              (numberOfDecisionsWithContext)  Mode  Cnt  Score   Error  Units
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              20    ss  250  0.289 ± 0.012  ms/op
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              50    ss  250  0.700 ± 0.304  ms/op

AFTER

Benchmark                                              (numberOfDecisionsWithContext)  Mode  Cnt  Score   Error  Units
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              20    ss  250  0.292 ± 0.011  ms/op
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              50    ss  250  0.706 ± 0.335  ms/op
```