### PR TITLE
Tuning parameters to improve accuracy for DMNEvaluateTriangularNumHard..

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/runtime/DMNEvaluateTriangularNumHardBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/runtime/DMNEvaluateTriangularNumHardBenchmark.java
@@ -38,8 +38,8 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
 
-@Warmup(iterations = 100)
-@Measurement(iterations = 50)
+@Warmup(iterations = 250)
+@Measurement(iterations = 100)
 public class DMNEvaluateTriangularNumHardBenchmark extends AbstractBenchmark {
 
     @Param({"20", "50"})


### PR DESCRIPTION
now baseline:

```
Benchmark                                              (numberOfDecisionsWithContext)  Mode  Cnt  Score   Error  Units
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              20    ss  500  0.190 ± 0.005  ms/op
DMNEvaluateTriangularNumHardBenchmark.evaluateContext                              50    ss  500  0.330 ± 0.008  ms/op
```

@baldimir 