### PR TITLE
Add a constraint stream benchmark for Traveling tournament example

### DIFF
--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/AbstractPlannerBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/AbstractPlannerBenchmark.java
@@ -17,9 +17,9 @@ import org.slf4j.LoggerFactory;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value = 1)
-@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 10)
+@Warmup(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractPlannerBenchmark<Solution_> {
 

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
@@ -1,0 +1,48 @@
+package org.jboss.qa.brms.performance.score.constraintstream;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.qa.brms.performance.AbstractPlannerBenchmark;
+import org.jboss.qa.brms.performance.examples.Examples;
+import org.jboss.qa.brms.performance.examples.travelingtournament.TravelingTournamentExample;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Warmup;
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
+
+@Fork(value = 4)
+@Warmup(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+public class TravelingTournamentConstraintStreamsBenchmark extends AbstractPlannerBenchmark<TravelingTournament> {
+
+    @Param({"SUPER_06", "SUPER_10", "SUPER_14"})
+    private TravelingTournamentExample.DataSet dataset;
+
+    @Override
+    protected TravelingTournament createInitialSolution() {
+        return Examples.TRAVELING_TOURNAMENT.loadSolvingProblem(TravelingTournamentExample.DataSet.SUPER_06);
+    }
+
+    @Override
+    protected Solver<TravelingTournament> createSolver() {
+        SolverFactory<TravelingTournament> solverFactory = SolverFactory.create(
+                Examples.TRAVELING_TOURNAMENT.getSolverConfigFromXml());
+        return solverFactory.buildSolver();
+    }
+
+    @Benchmark
+    public TravelingTournament benchmark() {
+        return runBenchmark();
+    }
+
+    public static void main(String[] args) {
+        TravelingTournamentConstraintStreamsBenchmark benchmark = new TravelingTournamentConstraintStreamsBenchmark();
+        Solver<TravelingTournament> solver = benchmark.createSolver();
+
+        solver.solve(Examples.TRAVELING_TOURNAMENT.loadSolvingProblem(TravelingTournamentExample.DataSet.SUPER_06));
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super06.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super06.xml
@@ -1,0 +1,418 @@
+<TravelingTournament id="1">
+  <id>0</id>
+  <dayList id="2">
+    <TtpDay id="3">
+      <id>0</id>
+      <index>0</index>
+      <nextDay id="4">
+        <id>1</id>
+        <index>1</index>
+        <nextDay id="5">
+          <id>2</id>
+          <index>2</index>
+          <nextDay id="6">
+            <id>3</id>
+            <index>3</index>
+            <nextDay id="7">
+              <id>4</id>
+              <index>4</index>
+              <nextDay id="8">
+                <id>5</id>
+                <index>5</index>
+                <nextDay id="9">
+                  <id>6</id>
+                  <index>6</index>
+                  <nextDay id="10">
+                    <id>7</id>
+                    <index>7</index>
+                    <nextDay id="11">
+                      <id>8</id>
+                      <index>8</index>
+                      <nextDay id="12">
+                        <id>9</id>
+                        <index>9</index>
+                      </nextDay>
+                    </nextDay>
+                  </nextDay>
+                </nextDay>
+              </nextDay>
+            </nextDay>
+          </nextDay>
+        </nextDay>
+      </nextDay>
+    </TtpDay>
+    <TtpDay reference="4"/>
+    <TtpDay reference="5"/>
+    <TtpDay reference="6"/>
+    <TtpDay reference="7"/>
+    <TtpDay reference="8"/>
+    <TtpDay reference="9"/>
+    <TtpDay reference="10"/>
+    <TtpDay reference="11"/>
+    <TtpDay reference="12"/>
+  </dayList>
+  <teamList id="13">
+    <TtpTeam id="14">
+      <id>0</id>
+      <name>BFN</name>
+      <distanceToTeamMap id="15">
+        <entry>
+          <TtpTeam reference="14"/>
+          <int>0</int>
+        </entry>
+        <entry>
+          <TtpTeam id="16">
+            <id>4</id>
+            <name>HLM</name>
+            <distanceToTeamMap id="17">
+              <entry>
+                <TtpTeam reference="14"/>
+                <int>7387</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="16"/>
+                <int>0</int>
+              </entry>
+              <entry>
+                <TtpTeam id="18">
+                  <id>3</id>
+                  <name>PRE</name>
+                  <distanceToTeamMap id="19">
+                    <entry>
+                      <TtpTeam reference="14"/>
+                      <int>226</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="16"/>
+                      <int>7546</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="18"/>
+                      <int>0</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam id="20">
+                        <id>2</id>
+                        <name>CAN</name>
+                        <distanceToTeamMap id="21">
+                          <entry>
+                            <TtpTeam reference="14"/>
+                            <int>6628</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="16"/>
+                            <int>1455</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="18"/>
+                            <int>6712</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="20"/>
+                            <int>0</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam id="22">
+                              <id>5</id>
+                              <name>SYD</name>
+                              <distanceToTeamMap id="23">
+                                <entry>
+                                  <TtpTeam reference="14"/>
+                                  <int>6782</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="16"/>
+                                  <int>1369</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="18"/>
+                                  <int>6867</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="20"/>
+                                  <int>154</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="22"/>
+                                  <int>0</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam id="24">
+                                    <id>1</id>
+                                    <name>AKL</name>
+                                    <distanceToTeamMap id="25">
+                                      <entry>
+                                        <TtpTeam reference="14"/>
+                                        <int>7431</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="16"/>
+                                        <int>71</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="18"/>
+                                        <int>7586</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="20"/>
+                                        <int>1429</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="22"/>
+                                        <int>1338</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="24"/>
+                                        <int>0</int>
+                                      </entry>
+                                    </distanceToTeamMap>
+                                  </TtpTeam>
+                                  <int>1338</int>
+                                </entry>
+                              </distanceToTeamMap>
+                            </TtpTeam>
+                            <int>154</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="24"/>
+                            <int>1429</int>
+                          </entry>
+                        </distanceToTeamMap>
+                      </TtpTeam>
+                      <int>6712</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="22"/>
+                      <int>6867</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="24"/>
+                      <int>7586</int>
+                    </entry>
+                  </distanceToTeamMap>
+                </TtpTeam>
+                <int>7546</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="20"/>
+                <int>1455</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="22"/>
+                <int>1369</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="24"/>
+                <int>71</int>
+              </entry>
+            </distanceToTeamMap>
+          </TtpTeam>
+          <int>7387</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="18"/>
+          <int>226</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="20"/>
+          <int>6628</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="22"/>
+          <int>6782</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="24"/>
+          <int>7431</int>
+        </entry>
+      </distanceToTeamMap>
+    </TtpTeam>
+    <TtpTeam reference="24"/>
+    <TtpTeam reference="20"/>
+    <TtpTeam reference="18"/>
+    <TtpTeam reference="16"/>
+    <TtpTeam reference="22"/>
+  </teamList>
+  <matchList id="26">
+    <TtpMatch id="27">
+      <id>0</id>
+      <homeTeam reference="14"/>
+      <awayTeam reference="24"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="28">
+      <id>1</id>
+      <homeTeam reference="14"/>
+      <awayTeam reference="20"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="29">
+      <id>2</id>
+      <homeTeam reference="14"/>
+      <awayTeam reference="18"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="30">
+      <id>3</id>
+      <homeTeam reference="14"/>
+      <awayTeam reference="16"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="31">
+      <id>4</id>
+      <homeTeam reference="14"/>
+      <awayTeam reference="22"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="32">
+      <id>5</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="14"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="33">
+      <id>6</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="20"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="34">
+      <id>7</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="18"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="35">
+      <id>8</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="16"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="36">
+      <id>9</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="22"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="37">
+      <id>10</id>
+      <homeTeam reference="20"/>
+      <awayTeam reference="14"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="38">
+      <id>11</id>
+      <homeTeam reference="20"/>
+      <awayTeam reference="24"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="39">
+      <id>12</id>
+      <homeTeam reference="20"/>
+      <awayTeam reference="18"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="40">
+      <id>13</id>
+      <homeTeam reference="20"/>
+      <awayTeam reference="16"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="41">
+      <id>14</id>
+      <homeTeam reference="20"/>
+      <awayTeam reference="22"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="42">
+      <id>15</id>
+      <homeTeam reference="18"/>
+      <awayTeam reference="14"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="43">
+      <id>16</id>
+      <homeTeam reference="18"/>
+      <awayTeam reference="24"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="44">
+      <id>17</id>
+      <homeTeam reference="18"/>
+      <awayTeam reference="20"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="45">
+      <id>18</id>
+      <homeTeam reference="18"/>
+      <awayTeam reference="16"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="46">
+      <id>19</id>
+      <homeTeam reference="18"/>
+      <awayTeam reference="22"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="47">
+      <id>20</id>
+      <homeTeam reference="16"/>
+      <awayTeam reference="14"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="48">
+      <id>21</id>
+      <homeTeam reference="16"/>
+      <awayTeam reference="24"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="49">
+      <id>22</id>
+      <homeTeam reference="16"/>
+      <awayTeam reference="20"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="50">
+      <id>23</id>
+      <homeTeam reference="16"/>
+      <awayTeam reference="18"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="51">
+      <id>24</id>
+      <homeTeam reference="16"/>
+      <awayTeam reference="22"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="52">
+      <id>25</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="14"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="53">
+      <id>26</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="24"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="54">
+      <id>27</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="20"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="55">
+      <id>28</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="18"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="56">
+      <id>29</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="16"/>
+      <day reference="12"/>
+    </TtpMatch>
+  </matchList>
+</TravelingTournament>

--- a/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super10.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super10.xml
@@ -1,0 +1,1098 @@
+<TravelingTournament id="1">
+  <id>0</id>
+  <dayList id="2">
+    <TtpDay id="3">
+      <id>0</id>
+      <index>0</index>
+      <nextDay id="4">
+        <id>1</id>
+        <index>1</index>
+        <nextDay id="5">
+          <id>2</id>
+          <index>2</index>
+          <nextDay id="6">
+            <id>3</id>
+            <index>3</index>
+            <nextDay id="7">
+              <id>4</id>
+              <index>4</index>
+              <nextDay id="8">
+                <id>5</id>
+                <index>5</index>
+                <nextDay id="9">
+                  <id>6</id>
+                  <index>6</index>
+                  <nextDay id="10">
+                    <id>7</id>
+                    <index>7</index>
+                    <nextDay id="11">
+                      <id>8</id>
+                      <index>8</index>
+                      <nextDay id="12">
+                        <id>9</id>
+                        <index>9</index>
+                        <nextDay id="13">
+                          <id>10</id>
+                          <index>10</index>
+                          <nextDay id="14">
+                            <id>11</id>
+                            <index>11</index>
+                            <nextDay id="15">
+                              <id>12</id>
+                              <index>12</index>
+                              <nextDay id="16">
+                                <id>13</id>
+                                <index>13</index>
+                                <nextDay id="17">
+                                  <id>14</id>
+                                  <index>14</index>
+                                  <nextDay id="18">
+                                    <id>15</id>
+                                    <index>15</index>
+                                    <nextDay id="19">
+                                      <id>16</id>
+                                      <index>16</index>
+                                      <nextDay id="20">
+                                        <id>17</id>
+                                        <index>17</index>
+                                      </nextDay>
+                                    </nextDay>
+                                  </nextDay>
+                                </nextDay>
+                              </nextDay>
+                            </nextDay>
+                          </nextDay>
+                        </nextDay>
+                      </nextDay>
+                    </nextDay>
+                  </nextDay>
+                </nextDay>
+              </nextDay>
+            </nextDay>
+          </nextDay>
+        </nextDay>
+      </nextDay>
+    </TtpDay>
+    <TtpDay reference="4"/>
+    <TtpDay reference="5"/>
+    <TtpDay reference="6"/>
+    <TtpDay reference="7"/>
+    <TtpDay reference="8"/>
+    <TtpDay reference="9"/>
+    <TtpDay reference="10"/>
+    <TtpDay reference="11"/>
+    <TtpDay reference="12"/>
+    <TtpDay reference="13"/>
+    <TtpDay reference="14"/>
+    <TtpDay reference="15"/>
+    <TtpDay reference="16"/>
+    <TtpDay reference="17"/>
+    <TtpDay reference="18"/>
+    <TtpDay reference="19"/>
+    <TtpDay reference="20"/>
+  </dayList>
+  <teamList id="21">
+    <TtpTeam id="22">
+      <id>0</id>
+      <name>BFN</name>
+      <distanceToTeamMap id="23">
+        <entry>
+          <TtpTeam id="24">
+            <id>7</id>
+            <name>CHC</name>
+            <distanceToTeamMap id="25">
+              <entry>
+                <TtpTeam reference="24"/>
+                <int>0</int>
+              </entry>
+              <entry>
+                <TtpTeam id="26">
+                  <id>4</id>
+                  <name>HLM</name>
+                  <distanceToTeamMap id="27">
+                    <entry>
+                      <TtpTeam reference="24"/>
+                      <int>419</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="26"/>
+                      <int>0</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam id="28">
+                        <id>1</id>
+                        <name>AKL</name>
+                        <distanceToTeamMap id="29">
+                          <entry>
+                            <TtpTeam reference="24"/>
+                            <int>474</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="26"/>
+                            <int>71</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="28"/>
+                            <int>0</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="22"/>
+                            <int>7431</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam id="30">
+                              <id>2</id>
+                              <name>CAN</name>
+                              <distanceToTeamMap id="31">
+                                <entry>
+                                  <TtpTeam reference="24"/>
+                                  <int>1369</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="26"/>
+                                  <int>1455</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="28"/>
+                                  <int>1429</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="22"/>
+                                  <int>6628</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="30"/>
+                                  <int>0</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam id="32">
+                                    <id>5</id>
+                                    <name>SYD</name>
+                                    <distanceToTeamMap id="33">
+                                      <entry>
+                                        <TtpTeam reference="24"/>
+                                        <int>1327</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="26"/>
+                                        <int>1369</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="28"/>
+                                        <int>1338</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="22"/>
+                                        <int>6782</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="30"/>
+                                        <int>154</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="32"/>
+                                        <int>0</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam id="34">
+                                          <id>6</id>
+                                          <name>JOH</name>
+                                          <distanceToTeamMap id="35">
+                                            <entry>
+                                              <TtpTeam reference="24"/>
+                                              <int>7113</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="26"/>
+                                              <int>7522</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="28"/>
+                                              <int>7563</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="22"/>
+                                              <int>232</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="30"/>
+                                              <int>6698</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="32"/>
+                                              <int>6852</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="34"/>
+                                              <int>0</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam id="36">
+                                                <id>8</id>
+                                                <name>BRI</name>
+                                                <distanceToTeamMap id="37">
+                                                  <entry>
+                                                    <TtpTeam reference="24"/>
+                                                    <int>1555</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="26"/>
+                                                    <int>1471</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="28"/>
+                                                    <int>1421</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="22"/>
+                                                    <int>7166</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="30"/>
+                                                    <int>588</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="32"/>
+                                                    <int>455</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="34"/>
+                                                    <int>7221</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="36"/>
+                                                    <int>0</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam id="38">
+                                                      <id>9</id>
+                                                      <name>DUR</name>
+                                                      <distanceToTeamMap id="39">
+                                                        <entry>
+                                                          <TtpTeam reference="24"/>
+                                                          <int>6805</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="26"/>
+                                                          <int>7214</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="28"/>
+                                                          <int>7254</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="22"/>
+                                                          <int>290</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="30"/>
+                                                          <int>6391</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="32"/>
+                                                          <int>6546</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="34"/>
+                                                          <int>311</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="36"/>
+                                                          <int>6919</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="38"/>
+                                                          <int>0</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam id="40">
+                                                            <id>3</id>
+                                                            <name>PRE</name>
+                                                            <distanceToTeamMap id="41">
+                                                              <entry>
+                                                                <TtpTeam reference="24"/>
+                                                                <int>7136</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="26"/>
+                                                                <int>7546</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="28"/>
+                                                                <int>7586</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="22"/>
+                                                                <int>226</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="30"/>
+                                                                <int>6712</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="32"/>
+                                                                <int>6867</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="34"/>
+                                                                <int>34</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="36"/>
+                                                                <int>7234</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="38"/>
+                                                                <int>332</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="40"/>
+                                                                <int>0</int>
+                                                              </entry>
+                                                            </distanceToTeamMap>
+                                                          </TtpTeam>
+                                                          <int>332</int>
+                                                        </entry>
+                                                      </distanceToTeamMap>
+                                                    </TtpTeam>
+                                                    <int>6919</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="40"/>
+                                                    <int>7234</int>
+                                                  </entry>
+                                                </distanceToTeamMap>
+                                              </TtpTeam>
+                                              <int>7221</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="38"/>
+                                              <int>311</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="40"/>
+                                              <int>34</int>
+                                            </entry>
+                                          </distanceToTeamMap>
+                                        </TtpTeam>
+                                        <int>6852</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="36"/>
+                                        <int>455</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="38"/>
+                                        <int>6546</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="40"/>
+                                        <int>6867</int>
+                                      </entry>
+                                    </distanceToTeamMap>
+                                  </TtpTeam>
+                                  <int>154</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="34"/>
+                                  <int>6698</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="36"/>
+                                  <int>588</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="38"/>
+                                  <int>6391</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="40"/>
+                                  <int>6712</int>
+                                </entry>
+                              </distanceToTeamMap>
+                            </TtpTeam>
+                            <int>1429</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="32"/>
+                            <int>1338</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="34"/>
+                            <int>7563</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="36"/>
+                            <int>1421</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="38"/>
+                            <int>7254</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="40"/>
+                            <int>7586</int>
+                          </entry>
+                        </distanceToTeamMap>
+                      </TtpTeam>
+                      <int>71</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="22"/>
+                      <int>7387</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="30"/>
+                      <int>1455</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="32"/>
+                      <int>1369</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="34"/>
+                      <int>7522</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="36"/>
+                      <int>1471</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="38"/>
+                      <int>7214</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="40"/>
+                      <int>7546</int>
+                    </entry>
+                  </distanceToTeamMap>
+                </TtpTeam>
+                <int>419</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="28"/>
+                <int>474</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="22"/>
+                <int>6974</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="30"/>
+                <int>1369</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="32"/>
+                <int>1327</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="34"/>
+                <int>7113</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="36"/>
+                <int>1555</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="38"/>
+                <int>6805</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="40"/>
+                <int>7136</int>
+              </entry>
+            </distanceToTeamMap>
+          </TtpTeam>
+          <int>6974</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="26"/>
+          <int>7387</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="28"/>
+          <int>7431</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="22"/>
+          <int>0</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="30"/>
+          <int>6628</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="32"/>
+          <int>6782</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="34"/>
+          <int>232</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="36"/>
+          <int>7166</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="38"/>
+          <int>290</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="40"/>
+          <int>226</int>
+        </entry>
+      </distanceToTeamMap>
+    </TtpTeam>
+    <TtpTeam reference="28"/>
+    <TtpTeam reference="30"/>
+    <TtpTeam reference="40"/>
+    <TtpTeam reference="26"/>
+    <TtpTeam reference="32"/>
+    <TtpTeam reference="34"/>
+    <TtpTeam reference="24"/>
+    <TtpTeam reference="36"/>
+    <TtpTeam reference="38"/>
+  </teamList>
+  <matchList id="42">
+    <TtpMatch id="43">
+      <id>0</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="28"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="44">
+      <id>1</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="30"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="45">
+      <id>2</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="40"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="46">
+      <id>3</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="26"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="47">
+      <id>4</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="32"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="48">
+      <id>5</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="34"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="49">
+      <id>6</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="24"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="50">
+      <id>7</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="36"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="51">
+      <id>8</id>
+      <homeTeam reference="22"/>
+      <awayTeam reference="38"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="52">
+      <id>9</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="22"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="53">
+      <id>10</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="30"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="54">
+      <id>11</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="40"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="55">
+      <id>12</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="26"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="56">
+      <id>13</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="32"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="57">
+      <id>14</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="34"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="58">
+      <id>15</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="24"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="59">
+      <id>16</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="36"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="60">
+      <id>17</id>
+      <homeTeam reference="28"/>
+      <awayTeam reference="38"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="61">
+      <id>18</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="22"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="62">
+      <id>19</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="28"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="63">
+      <id>20</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="40"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="64">
+      <id>21</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="26"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="65">
+      <id>22</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="32"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="66">
+      <id>23</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="34"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="67">
+      <id>24</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="24"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="68">
+      <id>25</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="36"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="69">
+      <id>26</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="38"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="70">
+      <id>27</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="22"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="71">
+      <id>28</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="28"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="72">
+      <id>29</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="30"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="73">
+      <id>30</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="26"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="74">
+      <id>31</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="32"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="75">
+      <id>32</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="34"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="76">
+      <id>33</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="24"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="77">
+      <id>34</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="36"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="78">
+      <id>35</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="38"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="79">
+      <id>36</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="22"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="80">
+      <id>37</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="28"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="81">
+      <id>38</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="30"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="82">
+      <id>39</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="40"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="83">
+      <id>40</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="32"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="84">
+      <id>41</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="34"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="85">
+      <id>42</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="24"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="86">
+      <id>43</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="36"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="87">
+      <id>44</id>
+      <homeTeam reference="26"/>
+      <awayTeam reference="38"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="88">
+      <id>45</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="22"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="89">
+      <id>46</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="28"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="90">
+      <id>47</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="30"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="91">
+      <id>48</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="40"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="92">
+      <id>49</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="26"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="93">
+      <id>50</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="34"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="94">
+      <id>51</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="24"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="95">
+      <id>52</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="36"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="96">
+      <id>53</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="38"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="97">
+      <id>54</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="22"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="98">
+      <id>55</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="28"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="99">
+      <id>56</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="30"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="100">
+      <id>57</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="40"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="101">
+      <id>58</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="26"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="102">
+      <id>59</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="32"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="103">
+      <id>60</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="24"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="104">
+      <id>61</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="36"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="105">
+      <id>62</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="38"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="106">
+      <id>63</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="22"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="107">
+      <id>64</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="28"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="108">
+      <id>65</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="30"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="109">
+      <id>66</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="40"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="110">
+      <id>67</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="26"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="111">
+      <id>68</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="32"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="112">
+      <id>69</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="34"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="113">
+      <id>70</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="36"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="114">
+      <id>71</id>
+      <homeTeam reference="24"/>
+      <awayTeam reference="38"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="115">
+      <id>72</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="22"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="116">
+      <id>73</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="28"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="117">
+      <id>74</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="30"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="118">
+      <id>75</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="40"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="119">
+      <id>76</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="26"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="120">
+      <id>77</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="32"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="121">
+      <id>78</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="34"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="122">
+      <id>79</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="24"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="123">
+      <id>80</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="38"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="124">
+      <id>81</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="22"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="125">
+      <id>82</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="28"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="126">
+      <id>83</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="30"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="127">
+      <id>84</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="40"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="128">
+      <id>85</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="26"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="129">
+      <id>86</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="32"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="130">
+      <id>87</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="34"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="131">
+      <id>88</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="24"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="132">
+      <id>89</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="36"/>
+      <day reference="11"/>
+    </TtpMatch>
+  </matchList>
+</TravelingTournament>

--- a/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super14.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/data/travelingtournament/4-super14.xml
@@ -1,0 +1,2098 @@
+<TravelingTournament id="1">
+  <id>0</id>
+  <dayList id="2">
+    <TtpDay id="3">
+      <id>0</id>
+      <index>0</index>
+      <nextDay id="4">
+        <id>1</id>
+        <index>1</index>
+        <nextDay id="5">
+          <id>2</id>
+          <index>2</index>
+          <nextDay id="6">
+            <id>3</id>
+            <index>3</index>
+            <nextDay id="7">
+              <id>4</id>
+              <index>4</index>
+              <nextDay id="8">
+                <id>5</id>
+                <index>5</index>
+                <nextDay id="9">
+                  <id>6</id>
+                  <index>6</index>
+                  <nextDay id="10">
+                    <id>7</id>
+                    <index>7</index>
+                    <nextDay id="11">
+                      <id>8</id>
+                      <index>8</index>
+                      <nextDay id="12">
+                        <id>9</id>
+                        <index>9</index>
+                        <nextDay id="13">
+                          <id>10</id>
+                          <index>10</index>
+                          <nextDay id="14">
+                            <id>11</id>
+                            <index>11</index>
+                            <nextDay id="15">
+                              <id>12</id>
+                              <index>12</index>
+                              <nextDay id="16">
+                                <id>13</id>
+                                <index>13</index>
+                                <nextDay id="17">
+                                  <id>14</id>
+                                  <index>14</index>
+                                  <nextDay id="18">
+                                    <id>15</id>
+                                    <index>15</index>
+                                    <nextDay id="19">
+                                      <id>16</id>
+                                      <index>16</index>
+                                      <nextDay id="20">
+                                        <id>17</id>
+                                        <index>17</index>
+                                        <nextDay id="21">
+                                          <id>18</id>
+                                          <index>18</index>
+                                          <nextDay id="22">
+                                            <id>19</id>
+                                            <index>19</index>
+                                            <nextDay id="23">
+                                              <id>20</id>
+                                              <index>20</index>
+                                              <nextDay id="24">
+                                                <id>21</id>
+                                                <index>21</index>
+                                                <nextDay id="25">
+                                                  <id>22</id>
+                                                  <index>22</index>
+                                                  <nextDay id="26">
+                                                    <id>23</id>
+                                                    <index>23</index>
+                                                    <nextDay id="27">
+                                                      <id>24</id>
+                                                      <index>24</index>
+                                                      <nextDay id="28">
+                                                        <id>25</id>
+                                                        <index>25</index>
+                                                      </nextDay>
+                                                    </nextDay>
+                                                  </nextDay>
+                                                </nextDay>
+                                              </nextDay>
+                                            </nextDay>
+                                          </nextDay>
+                                        </nextDay>
+                                      </nextDay>
+                                    </nextDay>
+                                  </nextDay>
+                                </nextDay>
+                              </nextDay>
+                            </nextDay>
+                          </nextDay>
+                        </nextDay>
+                      </nextDay>
+                    </nextDay>
+                  </nextDay>
+                </nextDay>
+              </nextDay>
+            </nextDay>
+          </nextDay>
+        </nextDay>
+      </nextDay>
+    </TtpDay>
+    <TtpDay reference="4"/>
+    <TtpDay reference="5"/>
+    <TtpDay reference="6"/>
+    <TtpDay reference="7"/>
+    <TtpDay reference="8"/>
+    <TtpDay reference="9"/>
+    <TtpDay reference="10"/>
+    <TtpDay reference="11"/>
+    <TtpDay reference="12"/>
+    <TtpDay reference="13"/>
+    <TtpDay reference="14"/>
+    <TtpDay reference="15"/>
+    <TtpDay reference="16"/>
+    <TtpDay reference="17"/>
+    <TtpDay reference="18"/>
+    <TtpDay reference="19"/>
+    <TtpDay reference="20"/>
+    <TtpDay reference="21"/>
+    <TtpDay reference="22"/>
+    <TtpDay reference="23"/>
+    <TtpDay reference="24"/>
+    <TtpDay reference="25"/>
+    <TtpDay reference="26"/>
+    <TtpDay reference="27"/>
+    <TtpDay reference="28"/>
+  </dayList>
+  <teamList id="29">
+    <TtpTeam id="30">
+      <id>0</id>
+      <name>BFN</name>
+      <distanceToTeamMap id="31">
+        <entry>
+          <TtpTeam id="32">
+            <id>8</id>
+            <name>BRI</name>
+            <distanceToTeamMap id="33">
+              <entry>
+                <TtpTeam reference="32"/>
+                <int>0</int>
+              </entry>
+              <entry>
+                <TtpTeam id="34">
+                  <id>1</id>
+                  <name>AKL</name>
+                  <distanceToTeamMap id="35">
+                    <entry>
+                      <TtpTeam reference="32"/>
+                      <int>1421</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="34"/>
+                      <int>0</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam id="36">
+                        <id>9</id>
+                        <name>DUR</name>
+                        <distanceToTeamMap id="37">
+                          <entry>
+                            <TtpTeam reference="32"/>
+                            <int>6919</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="34"/>
+                            <int>7254</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="36"/>
+                            <int>0</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam id="38">
+                              <id>3</id>
+                              <name>PRE</name>
+                              <distanceToTeamMap id="39">
+                                <entry>
+                                  <TtpTeam reference="32"/>
+                                  <int>7234</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="34"/>
+                                  <int>7586</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="36"/>
+                                  <int>332</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="38"/>
+                                  <int>0</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam id="40">
+                                    <id>10</id>
+                                    <name>DUN</name>
+                                    <distanceToTeamMap id="41">
+                                      <entry>
+                                        <TtpTeam reference="32"/>
+                                        <int>1564</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="34"/>
+                                        <int>641</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="36"/>
+                                        <int>6627</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="38"/>
+                                        <int>6958</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="40"/>
+                                        <int>0</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam id="42">
+                                          <id>2</id>
+                                          <name>CAN</name>
+                                          <distanceToTeamMap id="43">
+                                            <entry>
+                                              <TtpTeam reference="32"/>
+                                              <int>588</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="34"/>
+                                              <int>1429</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="36"/>
+                                              <int>6391</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="38"/>
+                                              <int>6712</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="40"/>
+                                              <int>1310</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="42"/>
+                                              <int>0</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam id="44">
+                                                <id>7</id>
+                                                <name>CHC</name>
+                                                <distanceToTeamMap id="45">
+                                                  <entry>
+                                                    <TtpTeam reference="32"/>
+                                                    <int>1555</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="34"/>
+                                                    <int>474</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="36"/>
+                                                    <int>6805</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="38"/>
+                                                    <int>7136</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="40"/>
+                                                    <int>179</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="42"/>
+                                                    <int>1369</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="44"/>
+                                                    <int>0</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam id="46">
+                                                      <id>13</id>
+                                                      <name>WLG</name>
+                                                      <distanceToTeamMap id="47">
+                                                        <entry>
+                                                          <TtpTeam reference="32"/>
+                                                          <int>1555</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="34"/>
+                                                          <int>306</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="36"/>
+                                                          <int>6994</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="38"/>
+                                                          <int>7325</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="40"/>
+                                                          <int>368</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="42"/>
+                                                          <int>1443</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="44"/>
+                                                          <int>189</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="46"/>
+                                                          <int>0</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam id="48">
+                                                            <id>12</id>
+                                                            <name>CPT</name>
+                                                            <distanceToTeamMap id="49">
+                                                              <entry>
+                                                                <TtpTeam reference="32"/>
+                                                                <int>7246</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="34"/>
+                                                                <int>7304</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="36"/>
+                                                                <int>785</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="38"/>
+                                                                <int>812</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="40"/>
+                                                                <int>6663</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="42"/>
+                                                                <int>6680</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="44"/>
+                                                                <int>6834</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="46"/>
+                                                                <int>7017</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="48"/>
+                                                                <int>0</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam id="50">
+                                                                  <id>4</id>
+                                                                  <name>HLM</name>
+                                                                  <distanceToTeamMap id="51">
+                                                                    <entry>
+                                                                      <TtpTeam reference="32"/>
+                                                                      <int>1471</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="34"/>
+                                                                      <int>71</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="36"/>
+                                                                      <int>7214</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="38"/>
+                                                                      <int>7546</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="40"/>
+                                                                      <int>592</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="42"/>
+                                                                      <int>1455</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="44"/>
+                                                                      <int>419</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="46"/>
+                                                                      <int>243</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="48"/>
+                                                                      <int>7253</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="50"/>
+                                                                      <int>0</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam id="52">
+                                                                        <id>6</id>
+                                                                        <name>JOH</name>
+                                                                        <distanceToTeamMap id="53">
+                                                                          <entry>
+                                                                            <TtpTeam reference="32"/>
+                                                                            <int>7221</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="34"/>
+                                                                            <int>7563</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="36"/>
+                                                                            <int>311</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="38"/>
+                                                                            <int>34</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="40"/>
+                                                                            <int>6935</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="42"/>
+                                                                            <int>6698</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="44"/>
+                                                                            <int>7113</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="46"/>
+                                                                            <int>7301</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="48"/>
+                                                                            <int>782</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="50"/>
+                                                                            <int>7522</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="52"/>
+                                                                            <int>0</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="30"/>
+                                                                            <int>232</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam id="54">
+                                                                              <id>5</id>
+                                                                              <name>SYD</name>
+                                                                              <distanceToTeamMap id="55">
+                                                                                <entry>
+                                                                                  <TtpTeam reference="32"/>
+                                                                                  <int>455</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="34"/>
+                                                                                  <int>1338</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="36"/>
+                                                                                  <int>6546</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="38"/>
+                                                                                  <int>6867</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="40"/>
+                                                                                  <int>1288</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="42"/>
+                                                                                  <int>154</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="44"/>
+                                                                                  <int>1327</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="46"/>
+                                                                                  <int>1381</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="48"/>
+                                                                                  <int>6832</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="50"/>
+                                                                                  <int>1369</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="52"/>
+                                                                                  <int>6852</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="30"/>
+                                                                                  <int>6782</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam reference="54"/>
+                                                                                  <int>0</int>
+                                                                                </entry>
+                                                                                <entry>
+                                                                                  <TtpTeam id="56">
+                                                                                    <id>11</id>
+                                                                                    <name>PER</name>
+                                                                                    <distanceToTeamMap id="57">
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="32"/>
+                                                                                        <int>2238</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="34"/>
+                                                                                        <int>3318</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="36"/>
+                                                                                        <int>4883</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="38"/>
+                                                                                        <int>5165</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="40"/>
+                                                                                        <int>3013</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="42"/>
+                                                                                        <int>1916</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="44"/>
+                                                                                        <int>3136</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="46"/>
+                                                                                        <int>3263</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="48"/>
+                                                                                        <int>5395</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="50"/>
+                                                                                        <int>3332</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="52"/>
+                                                                                        <int>5160</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="30"/>
+                                                                                        <int>5159</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="54"/>
+                                                                                        <int>2042</int>
+                                                                                      </entry>
+                                                                                      <entry>
+                                                                                        <TtpTeam reference="56"/>
+                                                                                        <int>0</int>
+                                                                                      </entry>
+                                                                                    </distanceToTeamMap>
+                                                                                  </TtpTeam>
+                                                                                  <int>2042</int>
+                                                                                </entry>
+                                                                              </distanceToTeamMap>
+                                                                            </TtpTeam>
+                                                                            <int>6852</int>
+                                                                          </entry>
+                                                                          <entry>
+                                                                            <TtpTeam reference="56"/>
+                                                                            <int>5160</int>
+                                                                          </entry>
+                                                                        </distanceToTeamMap>
+                                                                      </TtpTeam>
+                                                                      <int>7522</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="30"/>
+                                                                      <int>7387</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="54"/>
+                                                                      <int>1369</int>
+                                                                    </entry>
+                                                                    <entry>
+                                                                      <TtpTeam reference="56"/>
+                                                                      <int>3332</int>
+                                                                    </entry>
+                                                                  </distanceToTeamMap>
+                                                                </TtpTeam>
+                                                                <int>7253</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="52"/>
+                                                                <int>782</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="30"/>
+                                                                <int>563</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="54"/>
+                                                                <int>6832</int>
+                                                              </entry>
+                                                              <entry>
+                                                                <TtpTeam reference="56"/>
+                                                                <int>5395</int>
+                                                              </entry>
+                                                            </distanceToTeamMap>
+                                                          </TtpTeam>
+                                                          <int>7017</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="50"/>
+                                                          <int>243</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="52"/>
+                                                          <int>7301</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="30"/>
+                                                          <int>7162</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="54"/>
+                                                          <int>1381</int>
+                                                        </entry>
+                                                        <entry>
+                                                          <TtpTeam reference="56"/>
+                                                          <int>3263</int>
+                                                        </entry>
+                                                      </distanceToTeamMap>
+                                                    </TtpTeam>
+                                                    <int>189</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="48"/>
+                                                    <int>6834</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="50"/>
+                                                    <int>419</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="52"/>
+                                                    <int>7113</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="30"/>
+                                                    <int>6974</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="54"/>
+                                                    <int>1327</int>
+                                                  </entry>
+                                                  <entry>
+                                                    <TtpTeam reference="56"/>
+                                                    <int>3136</int>
+                                                  </entry>
+                                                </distanceToTeamMap>
+                                              </TtpTeam>
+                                              <int>1369</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="46"/>
+                                              <int>1443</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="48"/>
+                                              <int>6680</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="50"/>
+                                              <int>1455</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="52"/>
+                                              <int>6698</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="30"/>
+                                              <int>6628</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="54"/>
+                                              <int>154</int>
+                                            </entry>
+                                            <entry>
+                                              <TtpTeam reference="56"/>
+                                              <int>1916</int>
+                                            </entry>
+                                          </distanceToTeamMap>
+                                        </TtpTeam>
+                                        <int>1310</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="44"/>
+                                        <int>179</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="46"/>
+                                        <int>368</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="48"/>
+                                        <int>6663</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="50"/>
+                                        <int>592</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="52"/>
+                                        <int>6935</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="30"/>
+                                        <int>6797</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="54"/>
+                                        <int>1288</int>
+                                      </entry>
+                                      <entry>
+                                        <TtpTeam reference="56"/>
+                                        <int>3013</int>
+                                      </entry>
+                                    </distanceToTeamMap>
+                                  </TtpTeam>
+                                  <int>6958</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="42"/>
+                                  <int>6712</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="44"/>
+                                  <int>7136</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="46"/>
+                                  <int>7325</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="48"/>
+                                  <int>812</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="50"/>
+                                  <int>7546</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="52"/>
+                                  <int>34</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="30"/>
+                                  <int>226</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="54"/>
+                                  <int>6867</int>
+                                </entry>
+                                <entry>
+                                  <TtpTeam reference="56"/>
+                                  <int>5165</int>
+                                </entry>
+                              </distanceToTeamMap>
+                            </TtpTeam>
+                            <int>332</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="40"/>
+                            <int>6627</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="42"/>
+                            <int>6391</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="44"/>
+                            <int>6805</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="46"/>
+                            <int>6994</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="48"/>
+                            <int>785</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="50"/>
+                            <int>7214</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="52"/>
+                            <int>311</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="30"/>
+                            <int>290</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="54"/>
+                            <int>6546</int>
+                          </entry>
+                          <entry>
+                            <TtpTeam reference="56"/>
+                            <int>4883</int>
+                          </entry>
+                        </distanceToTeamMap>
+                      </TtpTeam>
+                      <int>7254</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="38"/>
+                      <int>7586</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="40"/>
+                      <int>641</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="42"/>
+                      <int>1429</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="44"/>
+                      <int>474</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="46"/>
+                      <int>306</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="48"/>
+                      <int>7304</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="50"/>
+                      <int>71</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="52"/>
+                      <int>7563</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="30"/>
+                      <int>7431</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="54"/>
+                      <int>1338</int>
+                    </entry>
+                    <entry>
+                      <TtpTeam reference="56"/>
+                      <int>3318</int>
+                    </entry>
+                  </distanceToTeamMap>
+                </TtpTeam>
+                <int>1421</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="36"/>
+                <int>6919</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="38"/>
+                <int>7234</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="40"/>
+                <int>1564</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="42"/>
+                <int>588</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="44"/>
+                <int>1555</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="46"/>
+                <int>1555</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="48"/>
+                <int>7246</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="50"/>
+                <int>1471</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="52"/>
+                <int>7221</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="30"/>
+                <int>7166</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="54"/>
+                <int>455</int>
+              </entry>
+              <entry>
+                <TtpTeam reference="56"/>
+                <int>2238</int>
+              </entry>
+            </distanceToTeamMap>
+          </TtpTeam>
+          <int>7166</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="34"/>
+          <int>7431</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="36"/>
+          <int>290</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="38"/>
+          <int>226</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="40"/>
+          <int>6797</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="42"/>
+          <int>6628</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="44"/>
+          <int>6974</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="46"/>
+          <int>7162</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="48"/>
+          <int>563</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="50"/>
+          <int>7387</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="52"/>
+          <int>232</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="30"/>
+          <int>0</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="54"/>
+          <int>6782</int>
+        </entry>
+        <entry>
+          <TtpTeam reference="56"/>
+          <int>5159</int>
+        </entry>
+      </distanceToTeamMap>
+    </TtpTeam>
+    <TtpTeam reference="34"/>
+    <TtpTeam reference="42"/>
+    <TtpTeam reference="38"/>
+    <TtpTeam reference="50"/>
+    <TtpTeam reference="54"/>
+    <TtpTeam reference="52"/>
+    <TtpTeam reference="44"/>
+    <TtpTeam reference="32"/>
+    <TtpTeam reference="36"/>
+    <TtpTeam reference="40"/>
+    <TtpTeam reference="56"/>
+    <TtpTeam reference="48"/>
+    <TtpTeam reference="46"/>
+  </teamList>
+  <matchList id="58">
+    <TtpMatch id="59">
+      <id>0</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="34"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="60">
+      <id>1</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="42"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="61">
+      <id>2</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="38"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="62">
+      <id>3</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="50"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="63">
+      <id>4</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="54"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="64">
+      <id>5</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="52"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="65">
+      <id>6</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="44"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="66">
+      <id>7</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="32"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="67">
+      <id>8</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="36"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="68">
+      <id>9</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="40"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="69">
+      <id>10</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="56"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="70">
+      <id>11</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="48"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="71">
+      <id>12</id>
+      <homeTeam reference="30"/>
+      <awayTeam reference="46"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="72">
+      <id>13</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="30"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="73">
+      <id>14</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="42"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="74">
+      <id>15</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="38"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="75">
+      <id>16</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="50"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="76">
+      <id>17</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="54"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="77">
+      <id>18</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="52"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="78">
+      <id>19</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="44"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="79">
+      <id>20</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="32"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="80">
+      <id>21</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="36"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="81">
+      <id>22</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="40"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="82">
+      <id>23</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="56"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="83">
+      <id>24</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="48"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="84">
+      <id>25</id>
+      <homeTeam reference="34"/>
+      <awayTeam reference="46"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="85">
+      <id>26</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="30"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="86">
+      <id>27</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="34"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="87">
+      <id>28</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="38"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="88">
+      <id>29</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="50"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="89">
+      <id>30</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="54"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="90">
+      <id>31</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="52"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="91">
+      <id>32</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="44"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="92">
+      <id>33</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="32"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="93">
+      <id>34</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="36"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="94">
+      <id>35</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="40"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="95">
+      <id>36</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="56"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="96">
+      <id>37</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="48"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="97">
+      <id>38</id>
+      <homeTeam reference="42"/>
+      <awayTeam reference="46"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="98">
+      <id>39</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="30"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="99">
+      <id>40</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="34"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="100">
+      <id>41</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="42"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="101">
+      <id>42</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="50"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="102">
+      <id>43</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="54"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="103">
+      <id>44</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="52"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="104">
+      <id>45</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="44"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="105">
+      <id>46</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="32"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="106">
+      <id>47</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="36"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="107">
+      <id>48</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="40"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="108">
+      <id>49</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="56"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="109">
+      <id>50</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="48"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="110">
+      <id>51</id>
+      <homeTeam reference="38"/>
+      <awayTeam reference="46"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="111">
+      <id>52</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="30"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="112">
+      <id>53</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="34"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="113">
+      <id>54</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="42"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="114">
+      <id>55</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="38"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="115">
+      <id>56</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="54"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="116">
+      <id>57</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="52"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="117">
+      <id>58</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="44"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="118">
+      <id>59</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="32"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="119">
+      <id>60</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="36"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="120">
+      <id>61</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="40"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="121">
+      <id>62</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="56"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="122">
+      <id>63</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="48"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="123">
+      <id>64</id>
+      <homeTeam reference="50"/>
+      <awayTeam reference="46"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="124">
+      <id>65</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="30"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="125">
+      <id>66</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="34"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="126">
+      <id>67</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="42"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="127">
+      <id>68</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="38"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="128">
+      <id>69</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="50"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="129">
+      <id>70</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="52"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="130">
+      <id>71</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="44"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="131">
+      <id>72</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="32"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="132">
+      <id>73</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="36"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="133">
+      <id>74</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="40"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="134">
+      <id>75</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="56"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="135">
+      <id>76</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="48"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="136">
+      <id>77</id>
+      <homeTeam reference="54"/>
+      <awayTeam reference="46"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="137">
+      <id>78</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="30"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="138">
+      <id>79</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="34"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="139">
+      <id>80</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="42"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="140">
+      <id>81</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="38"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="141">
+      <id>82</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="50"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="142">
+      <id>83</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="54"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="143">
+      <id>84</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="44"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="144">
+      <id>85</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="32"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="145">
+      <id>86</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="36"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="146">
+      <id>87</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="40"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="147">
+      <id>88</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="56"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="148">
+      <id>89</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="48"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="149">
+      <id>90</id>
+      <homeTeam reference="52"/>
+      <awayTeam reference="46"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="150">
+      <id>91</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="30"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="151">
+      <id>92</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="34"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="152">
+      <id>93</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="42"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="153">
+      <id>94</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="38"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="154">
+      <id>95</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="50"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="155">
+      <id>96</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="54"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="156">
+      <id>97</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="52"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="157">
+      <id>98</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="32"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="158">
+      <id>99</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="36"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="159">
+      <id>100</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="40"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="160">
+      <id>101</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="56"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="161">
+      <id>102</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="48"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="162">
+      <id>103</id>
+      <homeTeam reference="44"/>
+      <awayTeam reference="46"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="163">
+      <id>104</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="30"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="164">
+      <id>105</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="34"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="165">
+      <id>106</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="42"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="166">
+      <id>107</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="38"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="167">
+      <id>108</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="50"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="168">
+      <id>109</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="54"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="169">
+      <id>110</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="52"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="170">
+      <id>111</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="44"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="171">
+      <id>112</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="36"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="172">
+      <id>113</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="40"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="173">
+      <id>114</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="56"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="174">
+      <id>115</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="48"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="175">
+      <id>116</id>
+      <homeTeam reference="32"/>
+      <awayTeam reference="46"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="176">
+      <id>117</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="30"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="177">
+      <id>118</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="34"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="178">
+      <id>119</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="42"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="179">
+      <id>120</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="38"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="180">
+      <id>121</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="50"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="181">
+      <id>122</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="54"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="182">
+      <id>123</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="52"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="183">
+      <id>124</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="44"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="184">
+      <id>125</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="32"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="185">
+      <id>126</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="40"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="186">
+      <id>127</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="56"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="187">
+      <id>128</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="48"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="188">
+      <id>129</id>
+      <homeTeam reference="36"/>
+      <awayTeam reference="46"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="189">
+      <id>130</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="30"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="190">
+      <id>131</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="34"/>
+      <day reference="15"/>
+    </TtpMatch>
+    <TtpMatch id="191">
+      <id>132</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="42"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="192">
+      <id>133</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="38"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="193">
+      <id>134</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="50"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="194">
+      <id>135</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="54"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="195">
+      <id>136</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="52"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="196">
+      <id>137</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="44"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="197">
+      <id>138</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="32"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="198">
+      <id>139</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="36"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="199">
+      <id>140</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="56"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="200">
+      <id>141</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="48"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="201">
+      <id>142</id>
+      <homeTeam reference="40"/>
+      <awayTeam reference="46"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="202">
+      <id>143</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="30"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="203">
+      <id>144</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="34"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="204">
+      <id>145</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="42"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="205">
+      <id>146</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="38"/>
+      <day reference="23"/>
+    </TtpMatch>
+    <TtpMatch id="206">
+      <id>147</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="50"/>
+      <day reference="17"/>
+    </TtpMatch>
+    <TtpMatch id="207">
+      <id>148</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="54"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="208">
+      <id>149</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="52"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="209">
+      <id>150</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="44"/>
+      <day reference="12"/>
+    </TtpMatch>
+    <TtpMatch id="210">
+      <id>151</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="32"/>
+      <day reference="6"/>
+    </TtpMatch>
+    <TtpMatch id="211">
+      <id>152</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="36"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="212">
+      <id>153</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="40"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="213">
+      <id>154</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="48"/>
+      <day reference="8"/>
+    </TtpMatch>
+    <TtpMatch id="214">
+      <id>155</id>
+      <homeTeam reference="56"/>
+      <awayTeam reference="46"/>
+      <day reference="14"/>
+    </TtpMatch>
+    <TtpMatch id="215">
+      <id>156</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="30"/>
+      <day reference="22"/>
+    </TtpMatch>
+    <TtpMatch id="216">
+      <id>157</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="34"/>
+      <day reference="16"/>
+    </TtpMatch>
+    <TtpMatch id="217">
+      <id>158</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="42"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="218">
+      <id>159</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="38"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="219">
+      <id>160</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="50"/>
+      <day reference="24"/>
+    </TtpMatch>
+    <TtpMatch id="220">
+      <id>161</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="54"/>
+      <day reference="18"/>
+    </TtpMatch>
+    <TtpMatch id="221">
+      <id>162</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="52"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="222">
+      <id>163</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="44"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="223">
+      <id>164</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="32"/>
+      <day reference="13"/>
+    </TtpMatch>
+    <TtpMatch id="224">
+      <id>165</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="36"/>
+      <day reference="7"/>
+    </TtpMatch>
+    <TtpMatch id="225">
+      <id>166</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="40"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="226">
+      <id>167</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="56"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="227">
+      <id>168</id>
+      <homeTeam reference="48"/>
+      <awayTeam reference="46"/>
+      <day reference="28"/>
+    </TtpMatch>
+    <TtpMatch id="228">
+      <id>169</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="30"/>
+      <day reference="3"/>
+    </TtpMatch>
+    <TtpMatch id="229">
+      <id>170</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="34"/>
+      <day reference="4"/>
+    </TtpMatch>
+    <TtpMatch id="230">
+      <id>171</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="42"/>
+      <day reference="5"/>
+    </TtpMatch>
+    <TtpMatch id="231">
+      <id>172</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="38"/>
+      <day reference="19"/>
+    </TtpMatch>
+    <TtpMatch id="232">
+      <id>173</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="50"/>
+      <day reference="20"/>
+    </TtpMatch>
+    <TtpMatch id="233">
+      <id>174</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="54"/>
+      <day reference="21"/>
+    </TtpMatch>
+    <TtpMatch id="234">
+      <id>175</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="52"/>
+      <day reference="9"/>
+    </TtpMatch>
+    <TtpMatch id="235">
+      <id>176</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="44"/>
+      <day reference="10"/>
+    </TtpMatch>
+    <TtpMatch id="236">
+      <id>177</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="32"/>
+      <day reference="11"/>
+    </TtpMatch>
+    <TtpMatch id="237">
+      <id>178</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="36"/>
+      <day reference="25"/>
+    </TtpMatch>
+    <TtpMatch id="238">
+      <id>179</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="40"/>
+      <day reference="26"/>
+    </TtpMatch>
+    <TtpMatch id="239">
+      <id>180</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="56"/>
+      <day reference="27"/>
+    </TtpMatch>
+    <TtpMatch id="240">
+      <id>181</id>
+      <homeTeam reference="46"/>
+      <awayTeam reference="48"/>
+      <day reference="15"/>
+    </TtpMatch>
+  </matchList>
+</TravelingTournament>

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/Examples.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/Examples.java
@@ -5,6 +5,7 @@ import org.jboss.qa.brms.performance.examples.conferencescheduling.ConferenceSch
 import org.jboss.qa.brms.performance.examples.flightcrewscheduling.FlightCrewSchedulingExample;
 import org.jboss.qa.brms.performance.examples.nurserostering.NurseRosteringExample;
 import org.jboss.qa.brms.performance.examples.projectjobscheduling.ProjectJobSchedulingExample;
+import org.jboss.qa.brms.performance.examples.travelingtournament.TravelingTournamentExample;
 import org.jboss.qa.brms.performance.examples.tsp.TravelingSalesmanExample;
 import org.jboss.qa.brms.performance.examples.vehiclerouting.VehicleRoutingExample;
 
@@ -15,5 +16,6 @@ public class Examples {
     public static final NurseRosteringExample NURSE_ROSTERING = new NurseRosteringExample();
     public static final ProjectJobSchedulingExample PROJECT_JOB_SCHEDULING = new ProjectJobSchedulingExample();
     public static final TravelingSalesmanExample TRAVELING_SALESMAN = new TravelingSalesmanExample();
+    public static final TravelingTournamentExample TRAVELING_TOURNAMENT = new TravelingTournamentExample();
     public static final VehicleRoutingExample VEHICLE_ROUTING = new VehicleRoutingExample();
 }

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/TravelingTournamentExample.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/TravelingTournamentExample.java
@@ -1,0 +1,77 @@
+package org.jboss.qa.brms.performance.examples.travelingtournament;
+
+import java.io.File;
+
+import org.jboss.qa.brms.performance.examples.AbstractExample;
+import org.jboss.qa.brms.performance.examples.Examples;
+import org.jboss.qa.brms.performance.examples.travelingtournament.persistance.TravelingTournamentDao;
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.examples.travelingtournament.domain.Match;
+import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
+import org.optaplanner.examples.travelingtournament.optional.score.TravelingTournamentConstraintProvider;
+
+public final class TravelingTournamentExample extends AbstractExample<TravelingTournament> {
+
+    private static final String SOLVER_CONFIG =
+            "org/jboss/qa/brms/performance/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml";
+
+    private final TravelingTournamentDao dao = new TravelingTournamentDao();
+
+    @Override
+    public TravelingTournament loadSolvingProblem(File file) {
+        return dao.readSolution(file);
+    }
+
+    public TravelingTournament loadSolvingProblem(TravelingTournamentExample.DataSet dataset) {
+        return loadSolvingProblem(new File(dao.getDataDir(), dataset.getFilename()));
+    }
+
+    public TravelingTournament createInitialSolution(TravelingTournamentExample.DataSet dataSet) {
+        SolverConfig solverConfig = Examples.TRAVELING_TOURNAMENT.getBaseSolverConfig();
+
+        SolverFactory<TravelingTournament> solverFactory = SolverFactory.create(solverConfig);
+        Solver<TravelingTournament> constructionSolver = solverFactory.buildSolver();
+
+        TravelingTournament solution = Examples.TRAVELING_TOURNAMENT.loadSolvingProblem(dataSet);
+        constructionSolver.solve(solution);
+        return constructionSolver.getBestSolution();
+    }
+
+    @Override
+    public SolverConfig getBaseSolverConfig() {
+        return new SolverConfig()
+                .withSolutionClass(TravelingTournament.class)
+                .withEnvironmentMode(EnvironmentMode.REPRODUCIBLE)
+                .withEntityClasses(Match.class)
+                .withTerminationConfig(new TerminationConfig().withScoreCalculationCountLimit(10_000L))
+                .withScoreDirectorFactory(new ScoreDirectorFactoryConfig()
+                                                  .withConstraintProviderClass(TravelingTournamentConstraintProvider.class)
+                                                  .withInitializingScoreTrend("ONLY_DOWN"));
+    }
+
+    @Override
+    protected String getSolverConfigResource() {
+        return SOLVER_CONFIG;
+    }
+
+    public enum DataSet {
+        SUPER_06("4-super06.xml"),
+        SUPER_10("4-super10.xml"),
+        SUPER_14("4-super14.xml");
+
+        DataSet(String file) {
+            this.filename = file;
+        }
+
+        private String filename;
+
+        public String getFilename() {
+            return filename;
+        }
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/persistance/TravelingTournamentDao.java
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/persistance/TravelingTournamentDao.java
@@ -1,0 +1,11 @@
+package org.jboss.qa.brms.performance.examples.travelingtournament.persistance;
+
+import org.jboss.qa.brms.performance.persistence.XStreamSolutionDao;
+import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
+
+public class TravelingTournamentDao extends XStreamSolutionDao<TravelingTournament> {
+
+    public TravelingTournamentDao() {
+        super("travelingtournament", TravelingTournament.class);
+    }
+}

--- a/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/travelingtournament/solver/travelingTournamentSolverConfig.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver>
+  <solutionClass>org.optaplanner.examples.travelingtournament.domain.TravelingTournament</solutionClass>
+  <entityClass>org.optaplanner.examples.travelingtournament.domain.Match</entityClass>
+
+  <scoreDirectorFactory>
+    <constraintProviderClass>org.optaplanner.examples.travelingtournament.optional.score.TravelingTournamentConstraintProvider</constraintProviderClass>
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+  </scoreDirectorFactory>
+
+  <termination>
+    <scoreCalculationCountLimit>10000</scoreCalculationCountLimit>
+  </termination>
+
+  <localSearch>
+    <unionMoveSelector>
+      <swapMoveSelector>
+        <cacheType>PHASE</cacheType>
+        <selectionOrder>SHUFFLED</selectionOrder>
+        <filterClass>org.optaplanner.examples.travelingtournament.solver.move.factory.InverseMatchSwapMoveFilter</filterClass>
+      </swapMoveSelector>
+      <moveListFactory>
+        <cacheType>STEP</cacheType>
+        <selectionOrder>SHUFFLED</selectionOrder>
+        <moveListFactoryClass>org.optaplanner.examples.travelingtournament.solver.move.factory.MatchChainRotationsMoveFactory</moveListFactoryClass>
+      </moveListFactory>
+    </unionMoveSelector>
+    <acceptor>
+      <simulatedAnnealingStartingTemperature>2hard/10000soft</simulatedAnnealingStartingTemperature>
+    </acceptor>
+    <forager>
+      <acceptedCountLimit>4</acceptedCountLimit>
+    </forager>
+  </localSearch>
+</solver>


### PR DESCRIPTION
In addition to the benchmark, I've adjusted the default jmh params to comply with other examples.