### PR TITLE
JBPM-9044 - Upgrade kiegroup repos to Wildfly 18.0.1.Final

### DIFF
--- a/jbpm-benchmarks/kieserver-performance-tests/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests/pom.xml
@@ -94,7 +94,6 @@
         <artifactId>wildfly-jms-client-bom</artifactId>
         <version>${version.org.wildfly}</version>
         <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Import scope no longer needed after WildFly JMS Client BOM consolidation.