### PR TITLE
BAQE-1469 - Explicitly set the version of PostgreSQL JDBC Driver for …

### DIFF
--- a/jbpm-benchmarks/pom.xml
+++ b/jbpm-benchmarks/pom.xml
@@ -66,6 +66,13 @@
         <maven.jdbc.driver.class>org.postgresql.Driver</maven.jdbc.driver.class>
       </properties>
 
+      <dependencies>
+        <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+        </dependency>
+      </dependencies>
+
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
…sql-maven-plugin - put back normal driver dependency

I was too enthusiastic about the removal in #90 and forgot that the actual JDBC driver dependency is needed for jBPM engine itself :laughing: 