### PR TITLE
BAQE-1592 - Upgrade kie-benchmarks to JMH 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <version.jmh>1.21</version.jmh>
+    <version.jmh>1.26</version.jmh>
     <!-- This is here so we can override the version from parent, i.e. benchmark other version -->
     <kie.bom.version>${version.org.kie}</kie.bom.version>
   </properties>


### PR DESCRIPTION
This upgrade allows us to use the async-profiler [1] which integration was recently implemented on JMH.

[1] https://github.com/jvm-profiling-tools/async-profiler