### PR TITLE
BAQE-1611 - fix ecj dependency in drools benchmarks

### DIFF
--- a/drools-benchmarks/pom.xml
+++ b/drools-benchmarks/pom.xml
@@ -27,6 +27,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-ecj</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-decisiontables</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Descoping ECJ from Drools (DROOLS-5780) caused OOM error in Drools benchmarks.