### PR TITLE
BAQE-1706 - Fix of JBPM and Kie Server tests on jdk11

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTwoTimesProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTwoTimesProcess.java
@@ -54,6 +54,11 @@ public class LParallelGatewayTwoTimesProcess {
         jc = JBPMController.getInstance();
         jc.addWorkItemHandler("Manual Task", new ManualTaskWorkItemHandler());
         manager = jc.createRuntimeManager(ProcessStorage.ParallelGatewayTwoTimes.getPath());
+
+        // It seems that something is not thread safe and this initialization helps to prevent null-pointer exception.
+        RuntimeEngine runtimeEngine = jc.getRuntimeEngine();
+        KieSession ksession = runtimeEngine.getKieSession();
+        manager.disposeRuntimeEngine(runtimeEngine);
     }
 
     @BenchmarkMode(Mode.Throughput)

--- a/jbpm-benchmarks/kieserver-performance-tests/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <kit.version>${version.org.kie}</kit.version>
-    <metrics.version>3.1.0</metrics.version>
+    <metrics.version>4.1.18</metrics.version>
 
     <!-- >>>>>>>>>>>>>>>> Performance configuration <<<<<<<<<<<<<<<<<<<< -->
 
@@ -49,6 +49,8 @@
     <perfRepo.urlPath></perfRepo.urlPath>
     <perfRepo.username></perfRepo.username>
     <perfRepo.password></perfRepo.password>
+
+    <testUIDSuffix></testUIDSuffix>
 
     <!-- Measure - MemoryUsage,FileDescriptors,ThreadStates -->
     <measure>MemoryUsage,FileDescriptors,ThreadStates</measure>
@@ -187,6 +189,8 @@
             <argument>-DperfRepo.urlPath=${perfRepo.urlPath}</argument>
             <argument>-DperfRepo.username=${perfRepo.username}</argument>
             <argument>-DperfRepo.password=${perfRepo.password}</argument>
+
+            <argument>-DtestUIDSuffix=${testUIDSuffix}</argument>
 
             <argument>-DremoteAPI=${remoteAPI}</argument>
             <argument>-Dkieserver.username=${kieserver.username}</argument>

--- a/jbpm-benchmarks/kieserver-performance-tests/run.sh
+++ b/jbpm-benchmarks/kieserver-performance-tests/run.sh
@@ -95,6 +95,11 @@ then
   PARAMS="$PARAMS -DperfRepo.password=$perfRepo_password"
 fi
 
+if [ -n "$testUIDSuffix" ]
+then
+  PARAMS="$PARAMS -DtestUIDSuffix=$testUIDSuffix"
+fi
+
 if [ -n "$remoteAPI" ]
 then
   PARAMS="$PARAMS -DremoteAPI=$remoteAPI"


### PR DESCRIPTION
BAQE-1706 - Fix of JBPM and Kie Server tests on jdk11. Needs to be merged together with drools-integration PR as well as edit to bxms-qe-tests.