### PR TITLE
JBPM-9702 - Replace Travis with GitHub Actions workflow in kie-benchm…

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,38 @@
+name: PR Check
+
+on:
+  push:
+    branches:
+      - master
+      - 7.[0-9]+.x
+
+  pull_request:
+    branches:
+      - master
+      - 7.[0-9]+.x
+
+jobs:
+  pr-check:
+    name: Java ${{ matrix.java }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+      fail-fast: false
+    steps:
+      - name: Check  out Git repository
+        uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: adopt
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Maven Build using Java ${{ matrix.java-version }}
+        run: mvn -B --fail-at-end clean install

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ hs_err_pid*
 /*.ipr
 /*.iws
 /*.iml
-!/.travis.yml
+!/.github/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-jdk:
-  - openjdk8
-#  - openjdk11
-os:
-  - linux

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kie-benchmarks repository
+Kie-benchmarks repository [![PR Check Status Badge](https://github.com/kiegroup/kie-benchmarks/actions/workflows/pull_request.yml/badge.svg)](https://github.com/kiegroup/kie-benchmarks/actions/workflows/pull_request.yml)
 =========================
 This repository contains benchmarks from various areas of Kie group projects.  
 


### PR DESCRIPTION
…arks

Travis CI free plan has been deprecated some time ago:

https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing