### PR TITLE
BAQE-2017 - Adapt kie-benchmarks to move to jakarta apis

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/pom.xml
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/pom.xml
@@ -76,8 +76,8 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>
@@ -97,8 +97,8 @@
       <artifactId>kie-test-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jbpm-benchmarks/jbpm-performance-tests/pom.xml
+++ b/jbpm-benchmarks/jbpm-performance-tests/pom.xml
@@ -164,8 +164,8 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>
@@ -185,8 +185,8 @@
       <artifactId>kie-test-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jbpm-benchmarks/kieserver-performance-tests/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests/pom.xml
@@ -100,6 +100,10 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.jms</groupId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
+          </exclusion>
         </exclusions>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
This commit solves dependency issues introduced by moving to jakarta apis as a part of upgrade to wildfly 23:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/269da3638455a03becc7a10f8db7989a858536c4#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8
