### PR TITLE
Path fixes for OptaPlanner 7.x

### DIFF
--- a/optaplanner-7-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
+++ b/optaplanner-7-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
@@ -19,7 +19,7 @@ import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
 public class CloudBalanceBenchmark extends AbstractPlannerBenchmark<CloudBalance> {
 
     private static final String CLOUD_BALANCING_DROOLS_SCORE_RULES_FILE =
-            "org/optaplanner/examples/cloudbalancing/optional/score/cloudBalancingConstraints.drl";
+            "org/optaplanner/examples/cloudbalancing/solver/cloudBalancingConstraints.drl";
 
     @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
     private CloudBalancingExample.DataSet dataset;

--- a/optaplanner-7-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
+++ b/optaplanner-7-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
@@ -33,7 +33,7 @@ import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRoutingSolution> {
 
     private static final String VEHCILE_ROUTING_DROOLS_SCORE_RULES_FILE =
-            "org/optaplanner/examples/vehiclerouting/optional/score/vehicleRoutingConstraints.drl";
+            "org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingConstraints.drl";
     private static final int FORAGER_CONFIG_ACCEPTED_COUNT_LIMIT = 1;
     private static final int ACCEPTOR_CONFIG_LATE_ACCEPTANCE_SIZE = 200;
 

--- a/optaplanner-7-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
+++ b/optaplanner-7-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
@@ -33,7 +33,7 @@ import org.optaplanner.examples.conferencescheduling.domain.Talk;
 public final class ConferenceSchedulingExample extends AbstractExample<ConferenceSolution> {
 
     public static final String DRL_FILE =
-            "org/optaplanner/examples/conferencescheduling/optional/score/conferenceSchedulingConstraints.drl";
+            "org/optaplanner/examples/conferencescheduling/solver/conferenceSchedulingConstraints.drl";
 
     private static final String SOLVER_CONFIG =
             "/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";

--- a/optaplanner-7-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml
+++ b/optaplanner-7-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml
@@ -5,7 +5,7 @@
   <entityClass>org.optaplanner.examples.conferencescheduling.domain.Talk</entityClass>
 
   <scoreDirectorFactory>
-    <scoreDrl>org/jboss/qa/brms/performance/examples/conferencescheduling/optional/score/conferenceSchedulingConstraints.drl</scoreDrl>
+    <scoreDrl>org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingConstraints.drl</scoreDrl>
   </scoreDirectorFactory>
 
   <constructionHeuristic/>


### PR DESCRIPTION
Fixes for performance benchmarks according to example data set changes

Accidentally changed it in the wrong branch here 7540e42ffa535e7f6bc90da99830f9cdc7bddbfc 

https://qe-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/blue/organizations/jenkins/TESTING%2F_upstream%2Fconstraint_solving%2F7.x%2Fperf-optaplanner-upstream/detail/perf-optaplanner-upstream/19/pipeline