### PR TITLE
Kie-server perf tests - add missing wildfly client

### DIFF
--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/pom.xml
@@ -30,6 +30,11 @@
         </exclusions>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.wildfly.client</groupId>
+        <artifactId>wildfly-client-config</artifactId>
+        <version>${version.org.wildfly.client}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -68,6 +73,10 @@
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-jms-client-bom</artifactId>
       <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.client</groupId>
+      <artifactId>wildfly-client-config</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
Solves java.lang.NoClassDefFoundError: org/wildfly/client/config/ConfigXMLParseException

Example of failed run:
https://qe-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/custom/job/mcervena/job/BAQE-2014-generated/job/performance/job/perf-jmh-kie-server/17/console

This issue was not present in 7.60.SNAPSHOT