### PR TITLE
BAQE-2134 - Db cleaning in Teardown method of JMH tests

### DIFF
--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/pom.xml
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>jbpm-test</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>perf-tests-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
     </dependency>
@@ -103,6 +107,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
     </dependency>
   </dependencies>
 
@@ -182,7 +190,28 @@
         <maven.jdbc.url>jdbc:h2:mem:test;MVCC=true</maven.jdbc.url>
       </properties>
     </profile>
+    <profile>
+      <id>perfdb</id>
+      <!-- Use property activation so jbpm-performance-tests can run with H2 by default, i.e. when perfdb property
+           is not set. (h2 cannot be set as the default profile since then the perfdb profile from the parent won't
+           turn off the h2 profile from the child.) -->
+      <activation>
+        <property>
+          <name>perfdb</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>sql-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>
-
-

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksComplete.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksComplete.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
 import org.jbpm.test.performance.scenario.PrepareEngine;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.task.TaskService;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -26,7 +27,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class L1000HumanTasksComplete {
+public class L1000HumanTasksComplete extends AbstractJmhTest {
 
     static int taskId = 0;
     // ! Must be overridden using -p from command line

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksQueryPagination.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksQueryPagination.java
@@ -9,6 +9,7 @@ import org.jbpm.services.task.audit.service.TaskAuditService;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
 import org.jbpm.test.performance.scenario.PrepareEngine;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.task.TaskService;
 import org.kie.internal.query.QueryFilter;
 import org.kie.internal.task.api.AuditTask;
@@ -31,7 +32,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class L1000HumanTasksQueryPagination {
+public class L1000HumanTasksQueryPagination extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksStart.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000HumanTasksStart.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
 import org.jbpm.test.performance.scenario.PrepareEngine;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.task.TaskService;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -26,7 +27,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class L1000HumanTasksStart {
+public class L1000HumanTasksStart extends AbstractJmhTest {
 
     static int taskId = 0;
     // ! Must be overridden using -p from command line

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000ProcessesSignal.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/L1000ProcessesSignal.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class L1000ProcessesSignal {
+public class L1000ProcessesSignal extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LGroupHumanTaskProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LGroupHumanTaskProcess.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -29,7 +30,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LGroupHumanTaskProcess {
+public class LGroupHumanTaskProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LHumanTaskProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LHumanTaskProcess.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
@@ -31,7 +32,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LHumanTaskProcess {
+public class LHumanTaskProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LHumanTaskProcessWithListeners.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LHumanTaskProcessWithListeners.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
 import org.jbpm.test.performance.jbpm.constant.UserStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -29,7 +30,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LHumanTaskProcessWithListeners {
+public class LHumanTaskProcessWithListeners extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LIntermediateSignalProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LIntermediateSignalProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -26,7 +27,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LIntermediateSignalProcess {
+public class LIntermediateSignalProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LParallelGatewayProcess {
+public class LParallelGatewayProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTenTimesProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTenTimesProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LParallelGatewayTenTimesProcess {
+public class LParallelGatewayTenTimesProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTwoTimesProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LParallelGatewayTwoTimesProcess.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
 import org.jbpm.test.performance.jbpm.wih.ManualTaskWorkItemHandler;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
@@ -28,7 +29,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LParallelGatewayTwoTimesProcess {
+public class LParallelGatewayTwoTimesProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LRuleTaskProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LRuleTaskProcess.java
@@ -8,6 +8,7 @@ import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
 import org.jbpm.test.performance.jbpm.constant.RuleStorage;
 import org.jbpm.test.performance.jbpm.model.UserFact;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -30,7 +31,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LRuleTaskProcess {
+public class LRuleTaskProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LScriptTaskProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LScriptTaskProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LScriptTaskProcess {
+public class LScriptTaskProcess extends AbstractJmhTest {
 
     // ! Must be overridden using -p from command line
     @Param("")

--- a/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LStartEndProcess.java
+++ b/jbpm-benchmarks/jbpm-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LStartEndProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.jbpm.JBPMController;
 import org.jbpm.test.performance.jbpm.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LStartEndProcess {
+public class LStartEndProcess extends AbstractJmhTest {
 
     private static JBPMController jc;
 

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/pom.xml
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>kie-server-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>perf-tests-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-jms-client-bom</artifactId>
       <type>pom</type>
@@ -77,6 +81,16 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/filtered-resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -119,6 +133,32 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>perfdb</id>
+      <!-- Use property activation so jbpm-performance-tests can run with H2 by default, i.e. when perfdb property
+           is not set. (h2 cannot be set as the default profile since then the perfdb profile from the parent won't
+           turn off the h2 profile from the child.) -->
+      <activation>
+        <property>
+          <name>perfdb</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>sql-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 
   <developers>

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerGroupHumanTaskProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerGroupHumanTaskProcess.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
 import org.jbpm.test.performance.kieserver.constant.UserStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.ProcessServicesClient;
@@ -32,7 +33,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerGroupHumanTaskProcess {
+public class LServerGroupHumanTaskProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerHumanTaskProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerHumanTaskProcess.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
 import org.jbpm.test.performance.kieserver.constant.UserStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.ProcessServicesClient;
@@ -32,7 +33,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerHumanTaskProcess {
+public class LServerHumanTaskProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;
@@ -50,6 +51,9 @@ public class LServerHumanTaskProcess {
         processClient = client.getProcessClient();
         taskClient = client.getTaskClient();
         queryClient = client.getQueryClient();
+
+        // Single thread setup. Otherwise there will be a primary key violation when running parallel.
+        execute();
     }
 
     private void execute() {

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerParallelGatewayTwoTimesProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerParallelGatewayTwoTimesProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
@@ -27,7 +28,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerParallelGatewayTwoTimesProcess {
+public class LServerParallelGatewayTwoTimesProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;
@@ -43,6 +44,9 @@ public class LServerParallelGatewayTwoTimesProcess {
         client = new KieServerClient();
         processClient = client.getProcessClient();
         queryClient = client.getQueryClient();
+
+        // Single thread setup. Otherwise there will be a primary key violation when running parallel.
+        execute();
     }
 
     private void execute() {

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerRuleTaskProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerRuleTaskProcess.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.test.performance.jbpm.model.UserFact;
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
@@ -30,7 +31,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerRuleTaskProcess {
+public class LServerRuleTaskProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerStartEndNoCheckProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerStartEndNoCheckProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.client.ProcessServicesClient;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -25,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerStartEndNoCheckProcess {
+public class LServerStartEndNoCheckProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;

--- a/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerStartEndProcess.java
+++ b/jbpm-benchmarks/kieserver-performance-tests-jmh/src/main/java/org/jbpm/test/performance/scenario/load/LServerStartEndProcess.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jbpm.test.performance.kieserver.KieServerClient;
 import org.jbpm.test.performance.kieserver.constant.ProcessStorage;
+import org.jbpm.test.performance.test.common.AbstractJmhTest;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
@@ -27,7 +28,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 1, time = 1)
 @Measurement(iterations = 1, time = 1)
 @Threads(1)
-public class LServerStartEndProcess {
+public class LServerStartEndProcess extends AbstractJmhTest {
     // ! Must be overridden using -p from command line
     @Param("")
     public String remoteAPI;

--- a/jbpm-benchmarks/perf-tests-common/pom.xml
+++ b/jbpm-benchmarks/perf-tests-common/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>jbpm-benchmarks</artifactId>
+    <groupId>org.jbpm</groupId>
+    <version>7.64.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>perf-tests-common</artifactId>
+  <name>Performance Tests Common</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/jbpm-benchmarks/perf-tests-common/src/main/java/org/jbpm/test/performance/test/common/AbstractJmhTest.java
+++ b/jbpm-benchmarks/perf-tests-common/src/main/java/org/jbpm/test/performance/test/common/AbstractJmhTest.java
@@ -1,0 +1,41 @@
+package org.jbpm.test.performance.test.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.openjdk.jmh.annotations.TearDown;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract public class AbstractJmhTest {
+    static final Logger log = LoggerFactory.getLogger(AbstractJmhTest.class);
+
+    @TearDown
+    public void cleandb() throws MojoExecutionException, MavenInvocationException, IOException {
+        if (!Objects.equals(getProperties().getProperty("databaseName"), "H2")){
+            log.info("DB Cleaning");
+            PerfdbClean.cleandb();
+        }
+    }
+
+    private Properties getProperties() throws IOException, RuntimeException {
+        String DATASOURCE_PROPERTIES = "/datasource.properties";
+        InputStream propsInputStream = AbstractJmhTest.class.getResourceAsStream(DATASOURCE_PROPERTIES);
+        if (propsInputStream == null) {
+            throw new RuntimeException("Unable to load datasource properties [" + DATASOURCE_PROPERTIES + "]");
+        }
+        Properties props = new Properties();
+        try {
+            props.load(propsInputStream);
+        } catch (IOException ioe) {
+            log.error("Unable to load properties");
+            log.error("Stacktrace:", ioe);
+            throw ioe;
+        }
+        return props;
+    }
+}

--- a/jbpm-benchmarks/perf-tests-common/src/main/java/org/jbpm/test/performance/test/common/PerfdbClean.java
+++ b/jbpm-benchmarks/perf-tests-common/src/main/java/org/jbpm/test/performance/test/common/PerfdbClean.java
@@ -1,0 +1,38 @@
+package org.jbpm.test.performance.test.common;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
+public abstract class PerfdbClean {
+
+    public static void cleandb() throws MavenInvocationException, MojoExecutionException {
+        InvocationRequest request = getInvocationRequestForDbClean();
+        Invoker invoker = new DefaultInvoker();
+        invoker.setWorkingDirectory(new File(System.getProperty("user.dir")));
+        invoker.setMavenHome(new File(System.getProperty("mvn.home")));
+        invoker.getLogger().setThreshold(4);
+        InvocationResult result = invoker.execute(request);
+        if (result.getExitCode() != 0) {
+            throw new MojoExecutionException("Error during request invocation. See previous errors in log.", result.getExecutionException());
+        }
+    }
+
+    private static InvocationRequest getInvocationRequestForDbClean() {
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setUserSettingsFile(new File(System.getenv("MVN_SETTINGS")));
+        Properties properties = new Properties();
+        properties.setProperty("perfdb", "true");
+        request.setProperties(properties);
+        request.setGoals(Arrays.asList("process-resources"));
+        return request;
+    }
+}

--- a/jbpm-benchmarks/pom.xml
+++ b/jbpm-benchmarks/pom.xml
@@ -19,8 +19,19 @@
     <module>kieserver-performance-tests</module>
     <module>kieserver-performance-tests-jmh</module>
     <module>jbpm-performance-tests-jmh</module>
+    <module>perf-tests-common</module>
   </modules>
 
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>perf-tests-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
     <pluginManagement>
       <plugins>
@@ -149,16 +160,7 @@
             </plugin>
           </plugins>
         </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>properties-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>sql-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
+
       </build>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>${version.jmh}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven.shared</groupId>
+        <artifactId>maven-invoker</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Invoking sql-maven-plugin to drop and create schema in TearDown method of each test scenario so the DB is always fresh.

Needs to be merged **after** adapting JobDSLs to this change.