### PR TITLE
Introduce SMALLEST dataset

### DIFF
--- a/.github/workflows/pull_request_8.x.yml
+++ b/.github/workflows/pull_request_8.x.yml
@@ -36,5 +36,6 @@ jobs:
 
       - name: Check runtime
         working-directory: ./optaplanner-8-benchmarks
-        run: java -jar ./optaplanner-perf-benchmark/target/optaplanner-8-benchmarks.jar -jvmArgs '-Xms6144m -Xmx6144m' -v NORMAL -foe false -gc true -wi 1 -i 1 -f 1
+        run: java -jar ./optaplanner-perf-benchmark/target/optaplanner-8-benchmarks.jar -jvmArgs '-Xms6144m -Xmx6144m' -v NORMAL -foe false -gc true -wi 1 -i 1 -f 1 -p constructionHeuristicType=FIRST_FIT -p dataSet=SMALLEST 'org.jboss.qa.brms.performance.(?!.*scalability).*'
+
 

--- a/optaplanner-8-benchmarks/README.md
+++ b/optaplanner-8-benchmarks/README.md
@@ -24,7 +24,7 @@ Testing planner's performance regression in various tests.
      - can vary marginally from solution to solution
      - Change, Pillar Change, Swap, Pillar Swap, Sub Chain Change, Sub Chain Swap, Tail Chain Swap moves
      - tested separately
-       - some of them scale much worse than others on same dataSet
+       - some of them scale much worse than others on same dataset
          - different tuning for all tests is needed
     - constraint streams 
 

--- a/optaplanner-8-benchmarks/README.md
+++ b/optaplanner-8-benchmarks/README.md
@@ -24,7 +24,7 @@ Testing planner's performance regression in various tests.
      - can vary marginally from solution to solution
      - Change, Pillar Change, Swap, Pillar Swap, Sub Chain Change, Sub Chain Swap, Tail Chain Swap moves
      - tested separately
-       - some of them scale much worse than others on same dataset
+       - some of them scale much worse than others on same dataSet
          - different tuning for all tests is needed
     - constraint streams 
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/cloudbalance/CloudBalanceConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/cloudbalance/CloudBalanceConstructionBenchmark.java
@@ -13,8 +13,8 @@ public class CloudBalanceConstructionBenchmark extends AbstractConstructionHeuri
     @Param({"FIRST_FIT", "FIRST_FIT_DECREASING"})
     private ConstructionHeuristicType constructionHeuristicType;
 
-    @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
-    private CloudBalancingExample.DataSet dataset;
+    @Param({"SMALLEST", "CB_1600_4800", "CB_10000_30000"})
+    private CloudBalancingExample.DataSet dataSet;
 
     public CloudBalanceConstructionBenchmark() {
         super(Examples.CLOUD_BALANCING);
@@ -22,7 +22,7 @@ public class CloudBalanceConstructionBenchmark extends AbstractConstructionHeuri
 
     @Override
     protected CloudBalance createInitialSolution() {
-        return Examples.CLOUD_BALANCING.loadSolvingProblem(dataset);
+        return Examples.CLOUD_BALANCING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/projectjobscheduling/ProjectJobSchedulingConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/projectjobscheduling/ProjectJobSchedulingConstructionBenchmark.java
@@ -17,12 +17,12 @@ public class ProjectJobSchedulingConstructionBenchmark extends AbstractConstruct
     @Param({"FIRST_FIT"})
     private ConstructionHeuristicType constructionHeuristicType;
 
-    @Param({"A_4", "A_10", "B_9"})
-    private ProjectJobSchedulingExample.DataSet dataset;
+    @Param({"SMALLEST", "A_10", "B_9"})
+    private ProjectJobSchedulingExample.DataSet dataSet;
 
     @Override
     protected Schedule createInitialSolution() {
-        return Examples.PROJECT_JOB_SCHEDULING.loadSolvingProblem(dataset);
+        return Examples.PROJECT_JOB_SCHEDULING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/tsp/TSPConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/tsp/TSPConstructionBenchmark.java
@@ -17,12 +17,12 @@ public class TSPConstructionBenchmark extends AbstractConstructionHeuristicBench
     @Param({"FIRST_FIT", "FIRST_FIT_DECREASING"})
     private ConstructionHeuristicType constructionHeuristicType;
 
-    @Param({"LU_980", "USA_CA_2716", "GREECE_9882"})
-    private TravelingSalesmanExample.DataSet dataset;
+    @Param({"SMALLEST", "USA_CA_2716", "GREECE_9882"})
+    private TravelingSalesmanExample.DataSet dataSet;
 
     @Override
     protected TspSolution createInitialSolution() {
-        return Examples.TRAVELING_SALESMAN.loadSolvingProblem(dataset);
+        return Examples.TRAVELING_SALESMAN.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/vrp/VRPConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/vrp/VRPConstructionBenchmark.java
@@ -17,12 +17,12 @@ public class VRPConstructionBenchmark extends AbstractConstructionHeuristicBench
     @Param({"FIRST_FIT", "FIRST_FIT_DECREASING"})
     private ConstructionHeuristicType constructionHeuristicType;
 
-    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
-        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataset);
+        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/vrp/VRPTimeWindowedConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/vrp/VRPTimeWindowedConstructionBenchmark.java
@@ -25,8 +25,8 @@ public class VRPTimeWindowedConstructionBenchmark
     @Param({"FIRST_FIT", "FIRST_FIT_DECREASING"})
     private ConstructionHeuristicType constructionHeuristicType;
 
-    @Param({"BELGIUM_TW_50_10", "BELGIUM_TW_500_20", "BELGIUM_TW_2750_55"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "BELGIUM_TW_500_20", "BELGIUM_TW_2750_55"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected Solver<VehicleRoutingSolution> createSolver() {
@@ -41,7 +41,7 @@ public class VRPTimeWindowedConstructionBenchmark
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
-        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataset);
+        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/cloudbalance/AbstractCloudBalanceLocalSearchBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/cloudbalance/AbstractCloudBalanceLocalSearchBenchmark.java
@@ -18,8 +18,8 @@ import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
 
 public abstract class AbstractCloudBalanceLocalSearchBenchmark extends AbstractLocalSearchPlannerBenchmark<CloudBalance> {
 
-    @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
-    private CloudBalancingExample.DataSet dataset;
+    @Param({"SMALLEST", "CB_1600_4800", "CB_10000_30000"})
+    private CloudBalancingExample.DataSet dataSet;
 
     @Override
     protected CloudBalance createInitialSolution() {
@@ -33,7 +33,7 @@ public abstract class AbstractCloudBalanceLocalSearchBenchmark extends AbstractL
         SolverFactory<CloudBalance> solverFactory = SolverFactory.create(solverConfig);
         Solver<CloudBalance> constructionSolver = solverFactory.buildSolver();
 
-        CloudBalance solution = Examples.CLOUD_BALANCING.loadSolvingProblem(dataset);
+        CloudBalance solution = Examples.CLOUD_BALANCING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/AbstractNurseRosteringMoveSelectorBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/AbstractNurseRosteringMoveSelectorBenchmark.java
@@ -28,8 +28,8 @@ public abstract class AbstractNurseRosteringMoveSelectorBenchmark
     private static final int ACCEPTED_COUNT_LIMIT = 800;
     private static final long CALCULATION_COUNT_LIMIT = 10_000L;
 
-    @Param({"SPRINT", "MEDIUM", "LONG"})
-    private NurseRosteringExample.DataSet dataset;
+    @Param({"SMALLEST", "MEDIUM", "LONG"})
+    private NurseRosteringExample.DataSet dataSet;
 
     @Override
     protected NurseRoster createInitialSolution() {
@@ -42,7 +42,7 @@ public abstract class AbstractNurseRosteringMoveSelectorBenchmark
         SolverFactory<NurseRoster> solverFactory = SolverFactory.create(solverConfig);
         Solver<NurseRoster> constructionSolver = solverFactory.buildSolver();
 
-        NurseRoster nonInitializedSolution = Examples.NURSE_ROSTERING.loadSolvingProblem(dataset);
+        NurseRoster nonInitializedSolution = Examples.NURSE_ROSTERING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(nonInitializedSolution);
     }
 
@@ -88,7 +88,7 @@ public abstract class AbstractNurseRosteringMoveSelectorBenchmark
         return solverFactory.buildSolver();
     }
 
-    protected void setDataset(NurseRosteringExample.DataSet dataset) {
-        this.dataset = dataset;
+    protected void setDataset(NurseRosteringExample.DataSet dataSet) {
+        this.dataSet = dataSet;
     }
 }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/NurseRosteringSequentialPillarChangeMoveSelectorBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/NurseRosteringSequentialPillarChangeMoveSelectorBenchmark.java
@@ -31,7 +31,7 @@ public class NurseRosteringSequentialPillarChangeMoveSelectorBenchmark
         NurseRosteringSequentialPillarChangeMoveSelectorBenchmark nurseRosteringBenchmark =
                 new NurseRosteringSequentialPillarChangeMoveSelectorBenchmark();
         nurseRosteringBenchmark.initSolver();
-        nurseRosteringBenchmark.setDataset(NurseRosteringExample.DataSet.SPRINT);
+        nurseRosteringBenchmark.setDataset(NurseRosteringExample.DataSet.SMALLEST);
         nurseRosteringBenchmark.initSolution();
         nurseRosteringBenchmark.benchmark();
     }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/NurseRosteringSequentialPillarSwapMoveSelectorBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/nurserostering/moveselector/NurseRosteringSequentialPillarSwapMoveSelectorBenchmark.java
@@ -31,7 +31,7 @@ public class NurseRosteringSequentialPillarSwapMoveSelectorBenchmark
         NurseRosteringSequentialPillarSwapMoveSelectorBenchmark nurseRosteringBenchmark =
                 new NurseRosteringSequentialPillarSwapMoveSelectorBenchmark();
         nurseRosteringBenchmark.initSolver();
-        nurseRosteringBenchmark.setDataset(NurseRosteringExample.DataSet.SPRINT);
+        nurseRosteringBenchmark.setDataset(NurseRosteringExample.DataSet.SMALLEST);
         nurseRosteringBenchmark.initSolution();
         nurseRosteringBenchmark.benchmark();
     }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/projectjobscheduling/AbstractProjectJobSchedulingLocalSearchBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/projectjobscheduling/AbstractProjectJobSchedulingLocalSearchBenchmark.java
@@ -19,8 +19,8 @@ import org.optaplanner.examples.projectjobscheduling.domain.Schedule;
 public abstract class AbstractProjectJobSchedulingLocalSearchBenchmark
         extends AbstractLocalSearchPlannerBenchmark<Schedule> {
 
-    @Param({"A_4", "A_10", "B_9"})
-    private ProjectJobSchedulingExample.DataSet dataset;
+    @Param({"SMALLEST", "A_10", "B_9"})
+    private ProjectJobSchedulingExample.DataSet dataSet;
 
     @Override
     protected Schedule createInitialSolution() {
@@ -32,7 +32,7 @@ public abstract class AbstractProjectJobSchedulingLocalSearchBenchmark
         SolverFactory<Schedule> solverFactory = SolverFactory.create(solverConfig);
         Solver<Schedule> constructionSolver = solverFactory.buildSolver();
 
-        Schedule solution = Examples.PROJECT_JOB_SCHEDULING.loadSolvingProblem(dataset);
+        Schedule solution = Examples.PROJECT_JOB_SCHEDULING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/tsp/AbstractTSPLocalSearchBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/tsp/AbstractTSPLocalSearchBenchmark.java
@@ -19,8 +19,8 @@ import org.optaplanner.examples.tsp.domain.TspSolution;
 public abstract class AbstractTSPLocalSearchBenchmark
         extends AbstractLocalSearchPlannerBenchmark<TspSolution> {
 
-    @Param({"LU_980", "USA_CA_2716", "GREECE_9882"})
-    private TravelingSalesmanExample.DataSet dataset;
+    @Param({"SMALLEST", "USA_CA_2716", "GREECE_9882"})
+    private TravelingSalesmanExample.DataSet dataSet;
 
     @Override
     protected TspSolution createInitialSolution() {
@@ -33,7 +33,7 @@ public abstract class AbstractTSPLocalSearchBenchmark
         SolverFactory<TspSolution> solverFactory = SolverFactory.create(solverConfig);
         Solver<TspSolution> constructionSolver = solverFactory.buildSolver();
 
-        TspSolution solution = Examples.TRAVELING_SALESMAN.loadSolvingProblem(dataset);
+        TspSolution solution = Examples.TRAVELING_SALESMAN.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/vrp/AbstractVRPLocalSearchBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/vrp/AbstractVRPLocalSearchBenchmark.java
@@ -19,12 +19,12 @@ import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 public abstract class AbstractVRPLocalSearchBenchmark
         extends AbstractLocalSearchPlannerBenchmark<VehicleRoutingSolution> {
 
-    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
-        return Examples.VEHICLE_ROUTING.createInitialSolution(dataset);
+        return Examples.VEHICLE_ROUTING.createInitialSolution(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/vrptw/AbstractVRPTWLocalSearchBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/localsearch/vrptw/AbstractVRPTWLocalSearchBenchmark.java
@@ -20,8 +20,8 @@ import org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedC
 public abstract class AbstractVRPTWLocalSearchBenchmark
         extends AbstractLocalSearchPlannerBenchmark<VehicleRoutingSolution> {
 
-    @Param({"BELGIUM_TW_50_10", "BELGIUM_TW_500_20", "BELGIUM_TW_2750_55"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "BELGIUM_TW_500_20", "BELGIUM_TW_2750_55"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
@@ -37,7 +37,7 @@ public abstract class AbstractVRPTWLocalSearchBenchmark
         SolverFactory<VehicleRoutingSolution> solverFactory = SolverFactory.create(solverConfig);
         Solver<VehicleRoutingSolution> constructionSolver = solverFactory.buildSolver();
 
-        VehicleRoutingSolution solution = Examples.VEHICLE_ROUTING.loadSolvingProblem(dataset);
+        VehicleRoutingSolution solution = Examples.VEHICLE_ROUTING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
@@ -21,12 +21,12 @@ import org.optaplanner.examples.cloudbalancing.score.CloudBalancingConstraintPro
 public class CloudBalanceBenchmark extends AbstractPlannerBenchmark<CloudBalance> {
 
 
-    @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
-    private CloudBalancingExample.DataSet dataset;
+    @Param({"SMALLEST", "CB_1600_4800", "CB_10000_30000"})
+    private CloudBalancingExample.DataSet dataSet;
 
     @Override
     protected CloudBalance createInitialSolution() {
-        return Examples.CLOUD_BALANCING.loadSolvingProblem(dataset);
+        return Examples.CLOUD_BALANCING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
@@ -24,7 +24,7 @@ import org.optaplanner.examples.conferencescheduling.score.ConferenceSchedulingC
 @Warmup(iterations = 15)
 public class ConferenceSchedulingBenchmark extends AbstractPlannerBenchmark<ConferenceSolution> {
 
-    @Param({"TALKS_36_TIMESLOTS_12_ROOMS_5", "TALKS_108_TIMESLOTS_18_ROOMS_10", "TALKS_216_TIMESLOTS_18_ROOMS_20"})
+    @Param({"SMALLEST", "TALKS_36_TIMESLOTS_12_ROOMS_5", "TALKS_108_TIMESLOTS_18_ROOMS_10"})
     private ConferenceSchedulingExample.DataSet dataSet;
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/nurserostering/NurseRosteringBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/nurserostering/NurseRosteringBenchmark.java
@@ -14,12 +14,12 @@ import org.optaplanner.examples.nurserostering.domain.NurseRoster;
 @Warmup(iterations = 15)
 public class NurseRosteringBenchmark extends AbstractPlannerBenchmark<NurseRoster> {
 
-    @Param({"SPRINT", "MEDIUM", "LONG"})
-    private NurseRosteringExample.DataSet dataset;
+    @Param({"SMALLEST", "MEDIUM", "LONG"})
+    private NurseRosteringExample.DataSet dataSet;
 
     @Override
     protected NurseRoster createInitialSolution() {
-        return Examples.NURSE_ROSTERING.loadSolvingProblem(dataset);
+        return Examples.NURSE_ROSTERING.loadSolvingProblem(dataSet);
     }
 
     @Override
@@ -38,6 +38,6 @@ public class NurseRosteringBenchmark extends AbstractPlannerBenchmark<NurseRoste
     public static void main(String[] args) {
         NurseRosteringBenchmark nurseRosteringBenchmark = new NurseRosteringBenchmark();
         Solver<NurseRoster> solver = nurseRosteringBenchmark.createSolver();
-        solver.solve(Examples.NURSE_ROSTERING.loadSolvingProblem(NurseRosteringExample.DataSet.SPRINT));
+        solver.solve(Examples.NURSE_ROSTERING.loadSolvingProblem(NurseRosteringExample.DataSet.SMALLEST));
     }
 }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
@@ -37,12 +37,12 @@ public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRou
     private static final int FORAGER_CONFIG_ACCEPTED_COUNT_LIMIT = 1;
     private static final int ACCEPTOR_CONFIG_LATE_ACCEPTANCE_SIZE = 200;
 
-    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
-        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataset);
+        return Examples.VEHICLE_ROUTING.loadSolvingProblem(dataSet);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/scalability/CloudBalancingMultithreadedSolvingScalabilityBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/scalability/CloudBalancingMultithreadedSolvingScalabilityBenchmark.java
@@ -22,8 +22,8 @@ import org.optaplanner.examples.cloudbalancing.domain.CloudBalance;
 public class CloudBalancingMultithreadedSolvingScalabilityBenchmark
         extends AbstractMultithreadedSolvingScalabilityBenchmark<CloudBalance> {
 
-    @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
-    private CloudBalancingExample.DataSet dataset;
+    @Param({"SMALLEST","CB_100_300", "CB_1600_4800", "CB_10000_30000"})
+    private CloudBalancingExample.DataSet dataSet;
 
     @Override
     protected TerminationConfig getTerminationConfig() {
@@ -61,7 +61,7 @@ public class CloudBalancingMultithreadedSolvingScalabilityBenchmark
         SolverFactory<CloudBalance> solverFactory = SolverFactory.create(solverConfig);
         Solver<CloudBalance> constructionSolver = solverFactory.buildSolver();
 
-        CloudBalance solution = Examples.CLOUD_BALANCING.loadSolvingProblem(dataset);
+        CloudBalance solution = Examples.CLOUD_BALANCING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/scalability/VRPMultithreadedSolvingScalabilityBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/scalability/VRPMultithreadedSolvingScalabilityBenchmark.java
@@ -22,8 +22,8 @@ import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 public class VRPMultithreadedSolvingScalabilityBenchmark
         extends AbstractMultithreadedSolvingScalabilityBenchmark<VehicleRoutingSolution> {
 
-    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected TerminationConfig getTerminationConfig() {
@@ -61,7 +61,7 @@ public class VRPMultithreadedSolvingScalabilityBenchmark
         SolverFactory<VehicleRoutingSolution> solverFactory = SolverFactory.create(solverConfig);
         Solver<VehicleRoutingSolution> constructionSolver = solverFactory.buildSolver();
 
-        VehicleRoutingSolution solution = Examples.VEHICLE_ROUTING.loadSolvingProblem(dataset);
+        VehicleRoutingSolution solution = Examples.VEHICLE_ROUTING.loadSolvingProblem(dataSet);
         return constructionSolver.solve(solution);
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/FlightCrewSchedulingConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/FlightCrewSchedulingConstraintStreamsBenchmark.java
@@ -11,7 +11,7 @@ import org.optaplanner.examples.flightcrewscheduling.domain.FlightCrewSolution;
 
 public class FlightCrewSchedulingConstraintStreamsBenchmark extends AbstractPlannerBenchmark<FlightCrewSolution> {
 
-    @Param({"EUROPE_175_FLIGHTS_7_DAYS", "EUROPE_700_FLIGHTS_28_DAYS"})
+    @Param({"SMALLEST", "EUROPE_700_FLIGHTS_28_DAYS"})
     private FlightCrewSchedulingExample.DataSet dataSet;
 
     @Override
@@ -35,7 +35,7 @@ public class FlightCrewSchedulingConstraintStreamsBenchmark extends AbstractPlan
         FlightCrewSchedulingConstraintStreamsBenchmark benchmark = new FlightCrewSchedulingConstraintStreamsBenchmark();
         Solver<FlightCrewSolution> solver = benchmark.createSolver();
         FlightCrewSolution initialSolution = Examples.FLIGHT_CREW_SCHEDULING.createInitialSolution(
-                FlightCrewSchedulingExample.DataSet.EUROPE_175_FLIGHTS_7_DAYS);
+                FlightCrewSchedulingExample.DataSet.SMALLEST);
         FlightCrewSolution solution = solver.solve(initialSolution);
     }
 }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
@@ -19,8 +19,8 @@ import org.optaplanner.examples.travelingtournament.domain.TravelingTournament;
 @Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 public class TravelingTournamentConstraintStreamsBenchmark extends AbstractPlannerBenchmark<TravelingTournament> {
 
-    @Param({"SUPER_06", "SUPER_10", "SUPER_14"})
-    private TravelingTournamentExample.DataSet dataset;
+    @Param({"SUPER_06", "SMALLEST", "SUPER_14"})
+    private TravelingTournamentExample.DataSet dataSet;
 
     @Override
     protected TravelingTournament createInitialSolution() {

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/VehicleRoutingConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/VehicleRoutingConstraintStreamsBenchmark.java
@@ -11,12 +11,12 @@ import org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution;
 
 public class VehicleRoutingConstraintStreamsBenchmark extends AbstractPlannerBenchmark<VehicleRoutingSolution> {
 
-    @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
-    private VehicleRoutingExample.DataSet dataset;
+    @Param({"SMALLEST", "VRP_USA_1000_20", "VRP_USA_10000_100"})
+    private VehicleRoutingExample.DataSet dataSet;
 
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
-        return Examples.VEHICLE_ROUTING.createInitialSolution(dataset);
+        return Examples.VEHICLE_ROUTING.createInitialSolution(dataSet);
     }
 
     @Override
@@ -35,7 +35,7 @@ public class VehicleRoutingConstraintStreamsBenchmark extends AbstractPlannerBen
         VehicleRoutingConstraintStreamsBenchmark benchmark = new VehicleRoutingConstraintStreamsBenchmark();
         Solver<VehicleRoutingSolution> solver = benchmark.createSolver();
         VehicleRoutingSolution initialSolution = Examples.VEHICLE_ROUTING.createInitialSolution(
-                VehicleRoutingExample.DataSet.VRP_USA_100_10);
+                VehicleRoutingExample.DataSet.SMALLEST);
         VehicleRoutingSolution solution = solver.solve(initialSolution);
     }
 }

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/cloudbalancing/CloudBalancingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/cloudbalancing/CloudBalancingExample.java
@@ -24,8 +24,8 @@ public final class CloudBalancingExample extends AbstractExample<CloudBalance> {
         return dao.readSolution(file);
     }
 
-    public CloudBalance loadSolvingProblem(DataSet dataset) {
-        File dataFile = new File(dao.getDataDir(), dataset.getFilename());
+    public CloudBalance loadSolvingProblem(DataSet dataSet) {
+        File dataFile = new File(dao.getDataDir(), dataSet.getFilename());
         return loadSolvingProblem(dataFile);
     }
 
@@ -51,7 +51,7 @@ public final class CloudBalancingExample extends AbstractExample<CloudBalance> {
      * Predefined datasets.
      */
     public enum DataSet {
-        CB_400_1200("400computers-1200processes.xml"), CB_800_2400("800computers-2400processes.xml"),
+        SMALLEST("400computers-1200processes.xml"), CB_800_2400("800computers-2400processes.xml"),
         CB_1600_4800("1600computers-4800processes.xml"), CB_100_300("100computers-300processes.xml"),
         CB_10000_30000("10000computers-30000processes.xml");
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
@@ -35,16 +35,16 @@ public final class ConferenceSchedulingExample extends AbstractExample<Conferenc
     private static final String SOLVER_CONFIG =
             "/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
 
-    public ConferenceSolution loadSolvingProblem(ConferenceSchedulingExample.DataSet dataset) {
+    public ConferenceSolution loadSolvingProblem(ConferenceSchedulingExample.DataSet dataSet) {
         File exampleDataDir = new File(System.getProperty("user.dir"), "target");
         exampleDataDir.mkdirs();
         System.setProperty(CommonApp.DATA_DIR_SYSTEM_PROPERTY, exampleDataDir.getAbsolutePath());
         // TODO: refactor the ConferenceSchedulingGenerator in optaplanner-examples to reuse it
         return new ConferenceSchedulingGenerator().createConferenceSolution(
-                dataset.timeslotListSize,
-                dataset.roomListSize,
-                dataset.speakerListSize,
-                dataset.talkListSize);
+                dataSet.timeslotListSize,
+                dataSet.roomListSize,
+                dataSet.speakerListSize,
+                dataSet.talkListSize);
     }
 
     @Override
@@ -72,7 +72,7 @@ public final class ConferenceSchedulingExample extends AbstractExample<Conferenc
     public enum DataSet {
         TALKS_36_TIMESLOTS_12_ROOMS_5("TIME_12;ROOM_5;SPEAKER_26;TALK_36"),
         TALKS_108_TIMESLOTS_18_ROOMS_10("TIME_18;ROOM_10;SPEAKER_74;TALK_108"),
-        TALKS_216_TIMESLOTS_18_ROOMS_20("TIME_18;ROOM_20;SPEAKER_146;TALK_216");
+        SMALLEST("TIME_18;ROOM_20;SPEAKER_146;TALK_216");
 
         private int timeslotListSize;
         private int roomListSize;

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/flightcrewscheduling/FlightCrewSchedulingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/flightcrewscheduling/FlightCrewSchedulingExample.java
@@ -67,7 +67,7 @@ public class FlightCrewSchedulingExample extends AbstractExample<FlightCrewSolut
     }
 
     public enum DataSet {
-        EUROPE_175_FLIGHTS_7_DAYS("175flights-7days-Europe.xlsx"),
+        SMALLEST("175flights-7days-Europe.xlsx"),
         EUROPE_700_FLIGHTS_28_DAYS("700flights-28days-Europe.xlsx");
 
         DataSet(String file) {

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/nurserostering/NurseRosteringExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/nurserostering/NurseRosteringExample.java
@@ -17,8 +17,8 @@ public final class NurseRosteringExample extends AbstractExample<NurseRoster> {
 
     private final NurseRosteringDao dao = new NurseRosteringDao();
 
-    public NurseRoster loadSolvingProblem(DataSet dataset) {
-        return loadSolvingProblem(new File(dao.getDataDir(), dataset.getFilename()));
+    public NurseRoster loadSolvingProblem(DataSet dataSet) {
+        return loadSolvingProblem(new File(dao.getDataDir(), dataSet.getFilename()));
     }
 
     @Override
@@ -45,7 +45,7 @@ public final class NurseRosteringExample extends AbstractExample<NurseRoster> {
     public enum DataSet {
         LONG("long01.xml"),
         MEDIUM("medium01.xml"),
-        SPRINT("sprint01.xml");
+        SMALLEST("sprint01.xml");
 
         private String filename;
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/projectjobscheduling/ProjectJobSchedulingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/projectjobscheduling/ProjectJobSchedulingExample.java
@@ -16,8 +16,8 @@ public final class ProjectJobSchedulingExample extends AbstractExample<Schedule>
 
     private final ProjectJobSchedulingDao dao = new ProjectJobSchedulingDao();
 
-    public Schedule loadSolvingProblem(DataSet dataset) {
-        return loadSolvingProblem(new File(dao.getDataDir(), dataset.getFilename()));
+    public Schedule loadSolvingProblem(DataSet dataSet) {
+        return loadSolvingProblem(new File(dao.getDataDir(), dataSet.getFilename()));
     }
 
     @Override
@@ -45,7 +45,7 @@ public final class ProjectJobSchedulingExample extends AbstractExample<Schedule>
     }
 
     public enum DataSet {
-        A_4("A-4.xml"),
+        SMALLEST("A-4.xml"),
         A_10("A-10.xml"),
         B_9("B-9.xml");
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/TravelingTournamentExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/travelingtournament/TravelingTournamentExample.java
@@ -27,8 +27,8 @@ public final class TravelingTournamentExample extends AbstractExample<TravelingT
         return dao.readSolution(file);
     }
 
-    public TravelingTournament loadSolvingProblem(TravelingTournamentExample.DataSet dataset) {
-        return loadSolvingProblem(new File(dao.getDataDir(), dataset.getFilename()));
+    public TravelingTournament loadSolvingProblem(TravelingTournamentExample.DataSet dataSet) {
+        return loadSolvingProblem(new File(dao.getDataDir(), dataSet.getFilename()));
     }
 
     public TravelingTournament createInitialSolution(TravelingTournamentExample.DataSet dataSet) {
@@ -60,7 +60,7 @@ public final class TravelingTournamentExample extends AbstractExample<TravelingT
 
     public enum DataSet {
         SUPER_06("4-super06.xml"),
-        SUPER_10("4-super10.xml"),
+        SMALLEST("4-super10.xml"),
         SUPER_14("4-super14.xml");
 
         DataSet(String file) {

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/tsp/TravelingSalesmanExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/tsp/TravelingSalesmanExample.java
@@ -18,8 +18,8 @@ public final class TravelingSalesmanExample extends AbstractExample<TspSolution>
 
     private final TspDao dao = new TspDao();
 
-    public TspSolution loadSolvingProblem(DataSet dataset) {
-        File dataFile = new File(dao.getDataDir(), dataset.getFilename());
+    public TspSolution loadSolvingProblem(DataSet dataSet) {
+        File dataFile = new File(dao.getDataDir(), dataSet.getFilename());
         return loadSolvingProblem(dataFile);
     }
 
@@ -52,7 +52,7 @@ public final class TravelingSalesmanExample extends AbstractExample<TspSolution>
         USA_TX_2743("usa_tx_2743.xml"),
         CHINA_71009("ch71009.xml"),
         GREECE_9882("gr9882.xml"),
-        LU_980("lu980.xml");
+        SMALLEST("lu980.xml");
 
         DataSet(String file) {
             this.filename = file;

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/vehiclerouting/VehicleRoutingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/vehiclerouting/VehicleRoutingExample.java
@@ -27,8 +27,8 @@ public final class VehicleRoutingExample extends AbstractExample<VehicleRoutingS
 
     private final VehicleRoutingDao dao = new VehicleRoutingDao();
 
-    public VehicleRoutingSolution loadSolvingProblem(DataSet dataset) {
-        return loadSolvingProblem(new File(dao.getDataDir(), dataset.getFilename()));
+    public VehicleRoutingSolution loadSolvingProblem(DataSet dataSet) {
+        return loadSolvingProblem(new File(dao.getDataDir(), dataSet.getFilename()));
     }
 
     public VehicleRoutingSolution createInitialSolution(DataSet dataSet) {
@@ -73,7 +73,7 @@ public final class VehicleRoutingExample extends AbstractExample<VehicleRoutingS
         VRP_ROAD_29("road-cvrp-29customers.xml"),
         VRP_TW_25("cvrptw-25customers.xml"),
         VRP_TW_100_B("cvrptw-100customers-B.xml"),
-        VRP_USA_100_10("usa-n100-k10.xml"),
+        SMALLEST("usa-n100-k10.xml"),
         VRP_USA_1000_20("usa-n1000-k20.xml"),
         VRP_USA_10000_100("usa-n10000-k100.xml"),
         BELGIUM_TW_50_10("belgium-tw-n50-k10.xml"),


### PR DESCRIPTION
The idea is to map datasets that take less time to enable runtime check for PR changes.
This command
```
java -jar ./optaplanner-perf-benchmark/target/optaplanner-8-benchmarks.jar -jvmArgs '-Xms6144m -Xmx6144m' -v NORMAL -foe false -gc true -wi 1 -i 1 -f 1 -p constructionHeuristicType=FIRST_FIT -p dataSet=SMALLEST 'org.jboss.qa.brms.performance.(?!.*scalability).*'
```
will run non-scalability tests in quick mode

When performance tests starts at Friday and takes main branch of OptaPlanner it can fail not only on the build but in the runtime (for example if we change paths in optaplanner-examples) to avoid that and be able to include this as a part of CI I propose to create another tag for short datasets. That allows to run all tests in runtime for short datasets. That takes 4 minutes currently on my local.

Currently, will help as to catch the issues earlier when the new version of OptaPlanner gets changed