### PR TITLE
Add param test for checking package location of xml solver config

### DIFF
--- a/.github/workflows/pull_request_8.x.yml
+++ b/.github/workflows/pull_request_8.x.yml
@@ -33,8 +33,3 @@ jobs:
 
       - name: Maven Build
         run: mvn -B --fail-at-end clean install -f optaplanner-8-benchmarks
-
-      - name: Check runtime
-        working-directory: ./optaplanner-8-benchmarks
-        run: java -jar ./optaplanner-perf-benchmark/target/optaplanner-8-benchmarks.jar -jvmArgs '-Xms6144m -Xmx6144m' -v NORMAL -foe false -gc true -wi 1 -i 1 -f 1
-

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/pom.xml
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/pom.xml
@@ -47,6 +47,21 @@
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -78,6 +93,16 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
     </plugins>
+    <testResources>
+      <testResource>
+        <directory>../optaplanner-perf-framework/src/main/resources</directory>
+      </testResource>
+    </testResources>
   </build>
 </project>

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/tsp/TSPConstructionBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/construction/tsp/TSPConstructionBenchmark.java
@@ -20,6 +20,12 @@ public class TSPConstructionBenchmark extends AbstractConstructionHeuristicBench
     @Param({"LU_980", "USA_CA_2716", "GREECE_9882"})
     private TravelingSalesmanExample.DataSet dataset;
 
+    public TSPConstructionBenchmark(ConstructionHeuristicType constructionHeuristicType, TravelingSalesmanExample.DataSet dataset) {
+        super(Examples.TRAVELING_SALESMAN);
+        this.constructionHeuristicType = constructionHeuristicType;
+        this.dataset = dataset;
+    }
+
     @Override
     protected TspSolution createInitialSolution() {
         return Examples.TRAVELING_SALESMAN.loadSolvingProblem(dataset);

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
@@ -24,7 +24,8 @@ public class CloudBalanceBenchmark extends AbstractPlannerBenchmark<CloudBalance
     @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
     private CloudBalancingExample.DataSet dataset;
 
-    public CloudBalanceBenchmark(){}
+    public CloudBalanceBenchmark() {
+    }
 
     public CloudBalanceBenchmark(CloudBalancingExample.DataSet dataSet){
         this.dataset = dataSet;

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/cloudbalancing/CloudBalanceBenchmark.java
@@ -24,6 +24,12 @@ public class CloudBalanceBenchmark extends AbstractPlannerBenchmark<CloudBalance
     @Param({"CB_100_300", "CB_1600_4800", "CB_10000_30000"})
     private CloudBalancingExample.DataSet dataset;
 
+    public CloudBalanceBenchmark(){}
+
+    public CloudBalanceBenchmark(CloudBalancingExample.DataSet dataSet){
+        this.dataset = dataSet;
+    }
+
     @Override
     protected CloudBalance createInitialSolution() {
         return Examples.CLOUD_BALANCING.loadSolvingProblem(dataset);

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/conferencescheduling/ConferenceSchedulingBenchmark.java
@@ -25,11 +25,18 @@ import org.optaplanner.examples.conferencescheduling.score.ConferenceSchedulingC
 public class ConferenceSchedulingBenchmark extends AbstractPlannerBenchmark<ConferenceSolution> {
 
     @Param({"TALKS_36_TIMESLOTS_12_ROOMS_5", "TALKS_108_TIMESLOTS_18_ROOMS_10", "TALKS_216_TIMESLOTS_18_ROOMS_20"})
-    private ConferenceSchedulingExample.DataSet dataSet;
+    private ConferenceSchedulingExample.DataSet dataset;
+
+    public ConferenceSchedulingBenchmark() {
+    }
+
+    public ConferenceSchedulingBenchmark(ConferenceSchedulingExample.DataSet dataSet) {
+        this.dataset = dataSet;
+    }
 
     @Override
     protected ConferenceSolution createInitialSolution() {
-        return Examples.CONFERENCE_SCHEDULING.loadSolvingProblem(dataSet);
+        return Examples.CONFERENCE_SCHEDULING.loadSolvingProblem(dataset);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/nurserostering/NurseRosteringBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/nurserostering/NurseRosteringBenchmark.java
@@ -17,6 +17,13 @@ public class NurseRosteringBenchmark extends AbstractPlannerBenchmark<NurseRoste
     @Param({"SPRINT", "MEDIUM", "LONG"})
     private NurseRosteringExample.DataSet dataset;
 
+    public NurseRosteringBenchmark() {
+    }
+
+    public NurseRosteringBenchmark(NurseRosteringExample.DataSet dataset) {
+        this.dataset = dataset;
+    }
+
     @Override
     protected NurseRoster createInitialSolution() {
         return Examples.NURSE_ROSTERING.loadSolvingProblem(dataset);

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/FlightCrewSchedulingConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/FlightCrewSchedulingConstraintStreamsBenchmark.java
@@ -12,11 +12,18 @@ import org.optaplanner.examples.flightcrewscheduling.domain.FlightCrewSolution;
 public class FlightCrewSchedulingConstraintStreamsBenchmark extends AbstractPlannerBenchmark<FlightCrewSolution> {
 
     @Param({"EUROPE_175_FLIGHTS_7_DAYS", "EUROPE_700_FLIGHTS_28_DAYS"})
-    private FlightCrewSchedulingExample.DataSet dataSet;
+    private FlightCrewSchedulingExample.DataSet dataset;
+
+    public FlightCrewSchedulingConstraintStreamsBenchmark() {
+    }
+
+    public FlightCrewSchedulingConstraintStreamsBenchmark(FlightCrewSchedulingExample.DataSet dataSet) {
+        this.dataset = dataSet;
+    }
 
     @Override
     protected FlightCrewSolution createInitialSolution() {
-        return Examples.FLIGHT_CREW_SCHEDULING.createInitialSolution(dataSet);
+        return Examples.FLIGHT_CREW_SCHEDULING.createInitialSolution(dataset);
     }
 
     @Override

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/TravelingTournamentConstraintStreamsBenchmark.java
@@ -22,6 +22,13 @@ public class TravelingTournamentConstraintStreamsBenchmark extends AbstractPlann
     @Param({"SUPER_06", "SUPER_10", "SUPER_14"})
     private TravelingTournamentExample.DataSet dataset;
 
+    public TravelingTournamentConstraintStreamsBenchmark() {
+    }
+
+    public TravelingTournamentConstraintStreamsBenchmark(TravelingTournamentExample.DataSet dataset) {
+        this.dataset = dataset;
+    }
+
     @Override
     protected TravelingTournament createInitialSolution() {
         return Examples.TRAVELING_TOURNAMENT.loadSolvingProblem(TravelingTournamentExample.DataSet.SUPER_06);

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/VehicleRoutingConstraintStreamsBenchmark.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/score/constraintstream/VehicleRoutingConstraintStreamsBenchmark.java
@@ -14,6 +14,13 @@ public class VehicleRoutingConstraintStreamsBenchmark extends AbstractPlannerBen
     @Param({"VRP_USA_100_10", "VRP_USA_1000_20", "VRP_USA_10000_100"})
     private VehicleRoutingExample.DataSet dataset;
 
+    public VehicleRoutingConstraintStreamsBenchmark() {
+    }
+
+    public VehicleRoutingConstraintStreamsBenchmark(VehicleRoutingExample.DataSet dataset) {
+        this.dataset = dataset;
+    }
+
     @Override
     protected VehicleRoutingSolution createInitialSolution() {
         return Examples.VEHICLE_ROUTING.createInitialSolution(dataset);

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
@@ -31,8 +31,6 @@ import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
 class SolverConfigFromXmlTest {
 
-    private static final TerminationConfig oneStep = new TerminationConfig();
-
     private static Stream<Arguments> problemSetAndSolverConfig() {
         return Stream.of(
                 Arguments.of(new CloudBalanceBenchmark(CloudBalancingExample.DataSet.CB_100_300), Examples.CLOUD_BALANCING.getSolverConfigFromXml()),
@@ -45,11 +43,6 @@ class SolverConfigFromXmlTest {
         );
     }
 
-    @BeforeAll
-    public static void setTermination() {
-        oneStep.setStepCountLimit(1);
-    }
-
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @ParameterizedTest
     @MethodSource("problemSetAndSolverConfig")
@@ -57,7 +50,7 @@ class SolverConfigFromXmlTest {
 
         solverConfig.getPhaseConfigList().forEach(p -> {
             if (p instanceof LocalSearchPhaseConfig) {
-                p.setTerminationConfig(oneStep);
+                p.setTerminationConfig(new TerminationConfig().withStepCountLimit(1));
             }
         });
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
@@ -18,7 +18,6 @@ import org.jboss.qa.brms.performance.realworld.nurserostering.NurseRosteringBenc
 import org.jboss.qa.brms.performance.score.constraintstream.FlightCrewSchedulingConstraintStreamsBenchmark;
 import org.jboss.qa.brms.performance.score.constraintstream.TravelingTournamentConstraintStreamsBenchmark;
 import org.jboss.qa.brms.performance.score.constraintstream.VehicleRoutingConstraintStreamsBenchmark;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
@@ -1,0 +1,59 @@
+package org.jboss.qa.brms.performance;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.jboss.qa.brms.performance.construction.tsp.TSPConstructionBenchmark;
+import org.jboss.qa.brms.performance.examples.Examples;
+import org.jboss.qa.brms.performance.examples.cloudbalancing.CloudBalancingExample;
+import org.jboss.qa.brms.performance.examples.conferencescheduling.ConferenceSchedulingExample;
+import org.jboss.qa.brms.performance.examples.flightcrewscheduling.FlightCrewSchedulingExample;
+import org.jboss.qa.brms.performance.examples.nurserostering.NurseRosteringExample;
+import org.jboss.qa.brms.performance.examples.travelingtournament.TravelingTournamentExample;
+import org.jboss.qa.brms.performance.examples.tsp.TravelingSalesmanExample;
+import org.jboss.qa.brms.performance.examples.vehiclerouting.VehicleRoutingExample;
+import org.jboss.qa.brms.performance.realworld.cloudbalancing.CloudBalanceBenchmark;
+import org.jboss.qa.brms.performance.realworld.conferencescheduling.ConferenceSchedulingBenchmark;
+import org.jboss.qa.brms.performance.realworld.nurserostering.NurseRosteringBenchmark;
+import org.jboss.qa.brms.performance.score.constraintstream.FlightCrewSchedulingConstraintStreamsBenchmark;
+import org.jboss.qa.brms.performance.score.constraintstream.TravelingTournamentConstraintStreamsBenchmark;
+import org.jboss.qa.brms.performance.score.constraintstream.VehicleRoutingConstraintStreamsBenchmark;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+class SolverConfigFromXmlTest {
+
+    private static final TerminationConfig oneSecondTermination = new TerminationConfig();
+
+    private static Stream<Arguments> problemSetAndSolverConfig() {
+        return Stream.of(
+                Arguments.of(new CloudBalanceBenchmark(CloudBalancingExample.DataSet.CB_100_300), Examples.CLOUD_BALANCING.getSolverConfigFromXml()),
+                Arguments.of(new ConferenceSchedulingBenchmark(ConferenceSchedulingExample.DataSet.TALKS_36_TIMESLOTS_12_ROOMS_5), Examples.CONFERENCE_SCHEDULING.getSolverConfigFromXml()),
+                Arguments.of(new FlightCrewSchedulingConstraintStreamsBenchmark(FlightCrewSchedulingExample.DataSet.EUROPE_175_FLIGHTS_7_DAYS), Examples.FLIGHT_CREW_SCHEDULING.getSolverConfigFromXml()),
+                Arguments.of(new NurseRosteringBenchmark(NurseRosteringExample.DataSet.SPRINT), Examples.NURSE_ROSTERING.getSolverConfigFromXml()),
+                Arguments.of(new TSPConstructionBenchmark(ConstructionHeuristicType.FIRST_FIT, TravelingSalesmanExample.DataSet.LU_980), Examples.TRAVELING_SALESMAN.getSolverConfigFromXml()),
+                Arguments.of(new TravelingTournamentConstraintStreamsBenchmark(TravelingTournamentExample.DataSet.SUPER_06), Examples.TRAVELING_TOURNAMENT.getSolverConfigFromXml()),
+                Arguments.of(new VehicleRoutingConstraintStreamsBenchmark(VehicleRoutingExample.DataSet.VRP_USA_100_10), Examples.VEHICLE_ROUTING.getSolverConfigFromXml())
+        );
+    }
+
+    @BeforeAll
+    public static void terminationAndInitSolution() {
+        oneSecondTermination.setSecondsSpentLimit(1L);
+    }
+
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @ParameterizedTest
+    @MethodSource("problemSetAndSolverConfig")
+    public void solverConfigFromXmlTest(AbstractPlannerBenchmark benchmark, SolverConfig solverConfig) {
+        solverConfig.setTerminationConfig(oneSecondTermination);
+        SolverFactory.create(solverConfig).buildSolver().solve(benchmark.createInitialSolution());
+    }
+}

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
@@ -49,7 +49,7 @@ class SolverConfigFromXmlTest {
         oneSecondTermination.setSecondsSpentLimit(1L);
     }
 
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @ParameterizedTest
     @MethodSource("problemSetAndSolverConfig")
     public void solverConfigFromXmlTest(AbstractPlannerBenchmark benchmark, SolverConfig solverConfig) {

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/java/org/jboss/qa/brms/performance/SolverConfigFromXmlTest.java
@@ -25,12 +25,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
+import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
 class SolverConfigFromXmlTest {
 
-    private static final TerminationConfig oneSecondTermination = new TerminationConfig();
+    private static final TerminationConfig oneStep = new TerminationConfig();
 
     private static Stream<Arguments> problemSetAndSolverConfig() {
         return Stream.of(
@@ -45,15 +46,21 @@ class SolverConfigFromXmlTest {
     }
 
     @BeforeAll
-    public static void terminationAndInitSolution() {
-        oneSecondTermination.setSecondsSpentLimit(1L);
+    public static void setTermination() {
+        oneStep.setStepCountLimit(1);
     }
 
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @ParameterizedTest
     @MethodSource("problemSetAndSolverConfig")
     public void solverConfigFromXmlTest(AbstractPlannerBenchmark benchmark, SolverConfig solverConfig) {
-        solverConfig.setTerminationConfig(oneSecondTermination);
+
+        solverConfig.getPhaseConfigList().forEach(p -> {
+            if (p instanceof LocalSearchPhaseConfig) {
+                p.setTerminationConfig(oneStep);
+            }
+        });
+
         SolverFactory.create(solverConfig).buildSolver().solve(benchmark.createInitialSolution());
     }
 }

--- a/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/resources/logback-test.xml
+++ b/optaplanner-8-benchmarks/optaplanner-perf-benchmark/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %L lowers performance -->
+      <!--<pattern>%d [%t] %-5p %L%n  %m%n</pattern>-->
+      <pattern>%date [%logger{40}] %-5level %message%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.optaplanner" level="${logback.level.optaplanner:-warn}"/>
+
+  <root level="${logback.level.root:-warn}">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/cloudbalancing/CloudBalancingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/cloudbalancing/CloudBalancingExample.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 public final class CloudBalancingExample extends AbstractExample<CloudBalance> {
 
     private static final String SOLVER_CONFIG =
-            "/org/jboss/qa/brms/performance/examples/cloudbalancing/solver/cloudBalancingSolverConfig.xml";
+            "org/jboss/qa/brms/performance/examples/cloudbalancing/solver/cloudBalancingSolverConfig.xml";
 
     private final CloudBalancingDao dao = new CloudBalancingDao();
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/conferencescheduling/ConferenceSchedulingExample.java
@@ -33,7 +33,7 @@ import org.optaplanner.examples.conferencescheduling.score.ConferenceSchedulingC
 public final class ConferenceSchedulingExample extends AbstractExample<ConferenceSolution> {
 
     private static final String SOLVER_CONFIG =
-            "/org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
+            "org/jboss/qa/brms/performance/examples/conferencescheduling/solver/conferenceSchedulingSolverConfig.xml";
 
     public ConferenceSolution loadSolvingProblem(ConferenceSchedulingExample.DataSet dataset) {
         File exampleDataDir = new File(System.getProperty("user.dir"), "target");

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/tsp/TravelingSalesmanExample.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/examples/tsp/TravelingSalesmanExample.java
@@ -14,7 +14,7 @@ import org.optaplanner.examples.tsp.optional.score.TspIncrementalScoreCalculator
 
 public final class TravelingSalesmanExample extends AbstractExample<TspSolution> {
 
-    private static final String SOLVER_CONFIG = "/org/jboss/qa/brms/performance/examples/tsp/optional/score/tspSolverConfig.xml";
+    private static final String SOLVER_CONFIG = "org/jboss/qa/brms/performance/examples/tsp/solver/tspSolverConfig.xml";
 
     private final TspDao dao = new TspDao();
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/persistence/AbstractSolutionDao.java
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/java/org/jboss/qa/brms/performance/persistence/AbstractSolutionDao.java
@@ -35,8 +35,11 @@ public abstract class AbstractSolutionDao<Solution_> implements SolutionDao<Solu
                 ? new File("data/" + dirName)
                 : new File(MODULE_NAME + "/data/" + dirName);
         if (!dataDir.exists()) {
-            throw new IllegalStateException("The directory dataDir (" + dataDir.getAbsolutePath()
-                    + ") does not exist.\n");
+            dataDir = new File("../" + MODULE_NAME + "/data/" + dirName);
+            if (!dataDir.exists()) {
+                throw new IllegalStateException("The directory dataDir (" + dataDir.getAbsolutePath()
+                                                        + ") does not exist.\n");
+            }
         }
     }
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/tsp/solver/tspSolverConfig.xml
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/tsp/solver/tspSolverConfig.xml
@@ -6,7 +6,7 @@
 
   <scoreDirectorFactory>
     <scoreDefinitionType>SIMPLE_LONG</scoreDefinitionType>
-    <incrementalScoreCalculatorClass>org.optaplanner.examples.tsp.score.TspIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+    <incrementalScoreCalculatorClass>org.optaplanner.examples.tsp.optional.score.TspIncrementalScoreCalculator</incrementalScoreCalculatorClass>
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
 

--- a/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/tsp/solver/tspSolverConfig.xml
+++ b/optaplanner-8-benchmarks/optaplanner-perf-framework/src/main/resources/org/jboss/qa/brms/performance/examples/tsp/solver/tspSolverConfig.xml
@@ -19,7 +19,7 @@
   <localSearch>
     <unionMoveSelector>
       <changeMoveSelector>
-        <cacheType>PHASE</cacheType>
+        <cacheType>STEP</cacheType>
         <selectionOrder>SHUFFLED</selectionOrder>
       </changeMoveSelector>
       <!--<swapMoveSelector>-->


### PR DESCRIPTION
When optaplanner examples are change then the benchmarks fails during runtime
Added SolverConfigFromXmlTest.java to catch it during build time
Added constractors default and parametrized to initialize benchmarks with DataSet
Changed dataSet to dataset
fixed tspSolverConfig.xml

PR suggestion to load the data

Add solver config test

Add Test that will catch runtime exceptions if solver config xml file would need to change path to the xml files