### PR TITLE
BAQE-2275 - kie-benchmarks repository reorganization (main branch) - fix versioning

### DIFF
--- a/drools-benchmarks/pom.xml
+++ b/drools-benchmarks/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <version.freemaker>2.3.31</version.freemaker>
     <version.jaxb-api>2.0</version.jaxb-api>
+    <version.org.drools>${project.version}</version.org.drools>
   </properties>
 
   <dependencyManagement>
@@ -23,14 +24,14 @@
         <dependency>
           <groupId>org.drools</groupId>
           <artifactId>drools-bom</artifactId>
-          <version>${project.version}</version>
+          <version>${version.org.drools}</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
         <dependency>
           <groupId>org.kie</groupId>
           <artifactId>drools-build-parent</artifactId>
-          <version>${project.version}</version>
+          <version>${version.org.drools}</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <version.compiler>3.8.0</version.compiler>
     <maven.versions.plugin>2.8.1</maven.versions.plugin>
+    <version.org.optaplanner>${project.version}</version.org.optaplanner>
   </properties>
 
   <modules>
@@ -31,12 +32,12 @@
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>optaplanner-perf-framework</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.optaplanner}</version>
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>optaplanner-perf-benchmark</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.optaplanner}</version>
       </dependency>
       <!-- JMH -->
       <dependency>
@@ -53,14 +54,14 @@
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.optaplanner}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-build-parent</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.optaplanner}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -32,12 +32,12 @@
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>optaplanner-perf-framework</artifactId>
-        <version>${version.org.optaplanner}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>optaplanner-perf-benchmark</artifactId>
-        <version>${version.org.optaplanner}</version>
+        <version>${project.version}</version>
       </dependency>
       <!-- JMH -->
       <dependency>


### PR DESCRIPTION
-restore the version.org.{product} property to allow the benchmarks to be launched from the kogito CR pipeline