### PR TITLE
bump to 8.21.0-SNAPSHOT + fix compilation failures caused by DROOLS-6036

### DIFF
--- a/drools-benchmarks/pom.xml
+++ b/drools-benchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.20.0-SNAPSHOT</version>
+    <version>8.21.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/DummyProcessRuntime.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/DummyProcessRuntime.java
@@ -19,7 +19,6 @@ package org.drools.benchmarks.common.util;
 import java.util.Collection;
 import java.util.Map;
 
-import org.drools.core.event.ProcessEventSupport;
 import org.drools.core.runtime.process.InternalProcessRuntime;
 import org.kie.api.event.process.ProcessEventListener;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -31,11 +30,6 @@ public class DummyProcessRuntime implements InternalProcessRuntime {
 
     @Override
     public void dispose() {
-        // Nothing to do here.
-    }
-
-    @Override
-    public void setProcessEventSupport(final ProcessEventSupport processEventSupport) {
         // Nothing to do here.
     }
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/TestUtil.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/TestUtil.java
@@ -20,7 +20,7 @@ import org.drools.benchmarks.model.B;
 import org.drools.benchmarks.model.C;
 import org.drools.benchmarks.model.D;
 import org.drools.benchmarks.model.E;
-import org.drools.core.builder.conf.impl.DecisionTableConfigurationImpl;
+import org.drools.compiler.builder.conf.DecisionTableConfigurationImpl;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.KieSession;

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/pom.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>optaplanner-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.20.0-SNAPSHOT</version>
+    <version>8.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-perf-benchmark</artifactId>

--- a/optaplanner-benchmarks/optaplanner-perf-framework/pom.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-framework/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>optaplanner-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.20.0-SNAPSHOT</version>
+    <version>8.21.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>optaplanner-perf-framework</artifactId>

--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-benchmarks</artifactId>
     <groupId>org.kie</groupId>
-    <version>8.20.0-SNAPSHOT</version>
+    <version>8.21.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-benchmarks</artifactId>
-  <version>8.20.0-SNAPSHOT</version>
+  <version>8.21.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>KIE Benchmarks</name>


### PR DESCRIPTION
bump to 8.21.0-SNAPSHOT + fix compilation failures caused by DROOLS-6036 (isolate commands in their own module) made on 8.21.0-SNAPSHOT version of Drools