### PR TITLE
BAQE-2278 - adds an anchor (or default) parameter to turtle benchmarks in order to keep all the arrays with the same size in Horreum

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/AbstractBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/AbstractBenchmark.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
@@ -37,6 +38,15 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 20)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractBenchmark {
+
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
+    @Param({"true"})
+    private boolean anchor;
 
     protected KieBase kieBase;
     protected KieSession kieSession;

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/alphasupport/DMNDecisionTableAlphaSupportingDraftBench.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/alphasupport/DMNDecisionTableAlphaSupportingDraftBench.java
@@ -56,6 +56,15 @@ import org.slf4j.Logger;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class DMNDecisionTableAlphaSupportingDraftBench {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
+    @Param({"true"})
+    private boolean anchor;
+
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(DMNDecisionTableAlphaSupportingDraftBench.class);
     private DMNRuntime runtime;
     private DMNModel dmnModel;

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/buildtime/DMNBuildKJarBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/buildtime/DMNBuildKJarBenchmark.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -48,6 +49,15 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 15, time = 2, timeUnit = TimeUnit.SECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class DMNBuildKJarBenchmark {
+
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
+    @Param({"true"})
+    private boolean anchor;
 
     private final KieServices kieServices = KieServices.Factory.get();
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/AbstractFEELBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/AbstractFEELBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -39,6 +40,15 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 20, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public abstract class AbstractFEELBenchmark {
+
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
+    @Param({"true"})
+    private boolean anchor;
 
     private FEEL feelInterpreted;
     private FEEL feelCompiled;

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/EvaluationContextImplBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/dmn/feel/EvaluationContextImplBenchmark.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -36,6 +37,15 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 20, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class EvaluationContextImplBenchmark {
+
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
+    @Param({"true"})
+    private boolean anchor;
 
     private EvaluationContext context;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
@@ -42,6 +42,12 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractBuildtimeBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/AbstractBuildtimeBenchmark.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -40,6 +41,9 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 15, time = 5, timeUnit = TimeUnit.SECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractBuildtimeBenchmark {
+
+    @Param({"true"})
+    private boolean anchor;
 
     protected KieResources kieResources = KieServices.Factory.get().getResources();
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceBenchmark.java
@@ -45,6 +45,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKJarFromResourceBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceBenchmark.java
@@ -45,6 +45,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKJarFromResourceBenchmark {
 
+    @Param({"true"})
+    private boolean anchor;
+
     @Param({"true", "false"})
     private boolean useCanonicalModel;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceStoreFirstBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceStoreFirstBenchmark.java
@@ -45,6 +45,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKJarFromResourceStoreFirstBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceStoreFirstBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKJarFromResourceStoreFirstBenchmark.java
@@ -46,6 +46,9 @@ import org.openjdk.jmh.annotations.Warmup;
 public class BuildKJarFromResourceStoreFirstBenchmark {
 
     @Param({"true"})
+    private boolean anchor;
+
+    @Param({"true"})
     private boolean useCanonicalModel;
 
     @Param({"true", "false"})

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerBenchmark.java
@@ -48,6 +48,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKieBaseFromContainerBenchmark {
 
+    @Param({"true"})
+    private boolean anchor;
+
     @Param({"true", "false"})
     private boolean useCanonicalModel;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerBenchmark.java
@@ -48,6 +48,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKieBaseFromContainerBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerStoreFirstBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerStoreFirstBenchmark.java
@@ -49,6 +49,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BuildKieBaseFromContainerStoreFirstBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerStoreFirstBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/BuildKieBaseFromContainerStoreFirstBenchmark.java
@@ -50,6 +50,9 @@ import org.openjdk.jmh.annotations.Warmup;
 public class BuildKieBaseFromContainerStoreFirstBenchmark {
 
     @Param({"true"})
+    private boolean anchor;
+
+    @Param({"true"})
     private boolean useCanonicalModel;
 
     @Param({"true", "false"})

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleFusionRuntimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleFusionRuntimeBenchmark.java
@@ -28,11 +28,15 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 
 
 public abstract class AbstractSimpleFusionRuntimeBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"true"})
+    private boolean anchor;
 
     protected Map<EventSender, Integer> eventSenders;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleFusionRuntimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleFusionRuntimeBenchmark.java
@@ -35,6 +35,12 @@ import org.openjdk.jmh.annotations.TearDown;
 
 public abstract class AbstractSimpleFusionRuntimeBenchmark extends AbstractSimpleRuntimeBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleRuntimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleRuntimeBenchmark.java
@@ -41,6 +41,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -53,6 +54,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 20)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractSimpleRuntimeBenchmark {
+
+    @Param({"true"})
+    private boolean anchor;
 
     protected KieServices kieServices = KieServices.Factory.get();
     protected KieResources kieResources = KieServices.Factory.get().getResources();

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleRuntimeBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AbstractSimpleRuntimeBenchmark.java
@@ -55,6 +55,12 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class AbstractSimpleRuntimeBenchmark {
 
+    /**
+     * The param "anchor" is necessary to upload the performance results to (<a href="https://horreum.corp.redhat.com">Horreum</a>).
+     * When one of the tests uses parameters, Horreum expects at least one parameter per test.
+     * When a test has no parameter, there will be the dummy "anchor" which will make the update possible.
+     */
+
     @Param({"true"})
     private boolean anchor;
 


### PR DESCRIPTION
- it may be necessary to add it to other benchmarks as well (like DMN)