### PR TITLE
[kie-issues#53] Implement KieContainer load time benchmark

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks-module/.gitignore
+++ b/drools-benchmarks-parent/drools-benchmarks-module/.gitignore
@@ -1,0 +1,24 @@
+/target
+/local
+/bin
+
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
@@ -32,16 +32,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-maven-plugin</artifactId>
-          <version>${version.org.drools}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>drools-benchmarks-parent</artifactId>
+    <groupId>org.drools</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>kjar</packaging>
+
+  <artifactId>drools-benchmarks-module</artifactId>
+  <name>Drools 8 Benchmarks Module</name>
+  <description>Drools module to use for benchmarking purpose</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-api</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-model-compiler</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-canonical-model</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-core</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-compiler</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-dmn-core</artifactId>
+        <version>${version.org.drools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-benchmarks-common</artifactId>
+        <version>${version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-canonical-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-benchmarks-common</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-maven-plugin</artifactId>
+          <version>${version.org.drools}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Disable shading on this module -->
+            <phase>any-value-that-is-not-a-phase</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+
+  </build>
+
+
+</project>

--- a/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-module/pom.xml
@@ -17,68 +17,14 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-api</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-model-compiler</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-canonical-model</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-core</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-compiler</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-core</artifactId>
-        <version>${version.org.drools}</version>
-      </dependency>
-      <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-benchmarks-common</artifactId>
-        <version>${version}</version>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-model-compiler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-canonical-model</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-compiler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-dmn-core</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-benchmarks-common</artifactId>
@@ -98,8 +44,8 @@
 
     <plugins>
       <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-shade-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
             <!-- Disable shading on this module -->

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/META-INF/kmodule.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+  <kbase name="benchmarks-module" default="true" />
+</kmodule>

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/Traffic Violation.dmn
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/Traffic Violation.dmn
@@ -1,0 +1,230 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_1C792953-80DB-4B32-99EB-25FBE32BAF9E" name="Traffic Violation" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_63824D3F-9173-446D-A940-6A7F0FA056BB" name="tDriver" isCollection="false">
+    <dmn:itemComponent id="_9DAB5DAA-3B44-4F6D-87F2-95125FB2FEE4" name="Name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_856BA8FA-EF7B-4DF9-A1EE-E28263CE9955" name="Age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_FDC2CE03-D465-47C2-A311-98944E8CC23F" name="State" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_D6FD34C4-00DC-4C79-B1BF-BBCF6FC9B6D7" name="City" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_7110FE7E-1A38-4C39-B0EB-AEEF06BA37F4" name="Points" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_40731093-0642-4588-9183-1660FC55053B" name="tViolation" isCollection="false">
+    <dmn:itemComponent id="_39E88D9F-AE53-47AD-B3DE-8AB38D4F50B3" name="Code" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_1648EA0A-2463-4B54-A12A-D743A3E3EE7B" name="Date" isCollection="false">
+      <dmn:typeRef>date</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_9F129EAA-4E71-4D99-B6D0-84EEC3AC43CC" name="Type" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="enumeration" id="_626A8F9C-9DD1-44E0-9568-0F6F8F8BA228">
+        <dmn:text>"speed", "parking", "driving under the influence"</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_DDD10D6E-BD38-4C79-9E2F-8155E3A4B438" name="Speed Limit" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_229F80E4-2892-494C-B70D-683ABF2345F6" name="Actual Speed" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_2D4F30EE-21A6-4A78-A524-A5C238D433AE" name="tFine" isCollection="false">
+    <dmn:itemComponent id="_B9F70BC7-1995-4F51-B949-1AB65538B405" name="Amount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_F49085D6-8F08-4463-9A1A-EF6B57635DBD" name="Points" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_1929CBD5-40E0-442D-B909-49CEDE0101DC" name="Violation">
+    <dmn:variable id="_C16CF9B1-5FAB-48A0-95E0-5FCD661E0406" name="Violation" typeRef="tViolation"/>
+  </dmn:inputData>
+  <dmn:decision id="_4055D956-1C47-479C-B3F4-BAEB61F1C929" name="Fine">
+    <dmn:variable id="_8C1EAC83-F251-4D94-8A9E-B03ACF6849CD" name="Fine" typeRef="tFine"/>
+    <dmn:informationRequirement id="_800A3BBB-90A3-4D9D-BA5E-A311DED0134F">
+      <dmn:requiredInput href="#_1929CBD5-40E0-442D-B909-49CEDE0101DC"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_C8F7F579-E06C-4A2F-8485-65FAFAC3FE6A" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_B53A6F0D-F72C-41EF-96B3-F31269AC0FED">
+        <dmn:inputExpression id="_974C8D01-728F-4CE5-8C69-BE884125B859" typeRef="string">
+          <dmn:text>Violation.Type</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_D5319F80-1C59-4736-AF2D-D29DE6B7E76D">
+        <dmn:inputExpression id="_3FEB4DE3-90C6-438E-99BF-9BB1BF5B078A" typeRef="number">
+          <dmn:text>Violation.Actual Speed - Violation.Speed Limit</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_9012031F-9C01-44E5-8CD2-E6704D594504" name="Amount" typeRef="number"/>
+      <dmn:output id="_7CAC8240-E1A5-4FEB-A0D4-B8613F0DE54B" name="Points" typeRef="number"/>
+      <dmn:rule id="_424A80AE-916F-4451-9B6B-71557F7EC65A">
+        <dmn:inputEntry id="_EDA4F336-AA28-4F5F-ADFC-401E6DCC8D35">
+          <dmn:text>"speed"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_246AAB08-A945-4599-9220-7C24B6716FDD">
+          <dmn:text>[10..30)</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E49345EE-51D3-47C7-B658-3607E723FF37">
+          <dmn:text>500</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_1D56F3CB-6BAE-4415-940F-00F37121813D">
+          <dmn:text>3</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_B1ECE6A9-6B82-4A85-A7CA-5F96CDB0DCB6">
+        <dmn:inputEntry id="_2390F686-65CF-40FF-BF9A-72DFBAEBACAC">
+          <dmn:text>"speed"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_8CEBE4D5-DBEF-46EF-BD95-7B96148B6D8A">
+          <dmn:text>&gt;= 30</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_5FCC56B7-6BAA-4B09-AC61-7EB9D4CD58C3">
+          <dmn:text>1000</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_79FF8FDD-3299-4DFD-AA14-D2022504BDAD">
+          <dmn:text>7</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_8FC7068C-A3FD-44D9-AC2B-69C160A12E5D">
+        <dmn:inputEntry id="_02EEE8A9-1AD7-4708-8EC8-9B4177B05167">
+          <dmn:text>"parking"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_A5141FF4-8D63-49DB-8979-3B64A3BD9A82">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_EFDA632D-113D-46C9-94B8-78E9F9770CA4">
+          <dmn:text>100</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_05F86973-52CE-4C9D-B785-47B6340D10FD">
+          <dmn:text>1</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_A742DF2B-DC91-4166-9773-6EF86A45A625">
+        <dmn:inputEntry id="_F5B5AE87-D9E6-4142-B01D-D79D4BA49EEE">
+          <dmn:text>"driving under the influence"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_BD2A43F5-46D8-436A-B8A1-D98747C836B1">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_ECAF3378-46B6-4F40-B95A-E90DB700BF7D">
+          <dmn:text>1000</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_F0016A9C-D1D0-472A-9FB3-ABE77AD15F7D">
+          <dmn:text>5</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:inputData id="_1F9350D7-146D-46F1-85D8-15B5B68AF22A" name="Driver">
+    <dmn:variable id="_A80F16DF-0DB4-43A2-B041-32900B1A3F3D" name="Driver" typeRef="tDriver"/>
+  </dmn:inputData>
+  <dmn:decision id="_8A408366-D8E9-4626-ABF3-5F69AA01F880" name="Should the driver be suspended?">
+    <dmn:question>Should the driver be suspended due to points on his license?</dmn:question>
+    <dmn:allowedAnswers>"Yes", "No"</dmn:allowedAnswers>
+    <dmn:variable id="_40387B66-5D00-48C8-BB90-E83EE3332C72" name="Should the driver be suspended?" typeRef="string"/>
+    <dmn:informationRequirement id="_982211B1-5246-49CD-BE85-3211F71253CF">
+      <dmn:requiredInput href="#_1F9350D7-146D-46F1-85D8-15B5B68AF22A"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_AEC4AA5F-50C3-4FED-A0C2-261F90290731">
+      <dmn:requiredDecision href="#_4055D956-1C47-479C-B3F4-BAEB61F1C929"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_F39732F1-0AA7-468F-86C4-DCC07E6F81CF">
+      <dmn:contextEntry>
+        <dmn:variable id="_09385E8D-68E0-4DFD-AAD8-141C15C96B71" name="Total Points" typeRef="number"/>
+        <dmn:literalExpression id="_F1BEBF16-033F-4A25-9523-CAC23ACC5DFC">
+          <dmn:text>Driver.Points + Fine.Points</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:literalExpression id="_1929D813-B1C9-43C5-9497-CE5D8B2B040C">
+          <dmn:text>if Total Points >= 20 then "Yes" else "No"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_C8F7F579-E06C-4A2F-8485-65FAFAC3FE6A">
+            <kie:width>50.0</kie:width>
+            <kie:width>254.0</kie:width>
+            <kie:width>329.0</kie:width>
+            <kie:width>119.0</kie:width>
+            <kie:width>100.0</kie:width>
+            <kie:width>186.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_F39732F1-0AA7-468F-86C4-DCC07E6F81CF">
+            <kie:width>50.0</kie:width>
+            <kie:width>100.0</kie:width>
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_F1BEBF16-033F-4A25-9523-CAC23ACC5DFC">
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_1929D813-B1C9-43C5-9497-CE5D8B2B040C">
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_1929CBD5-40E0-442D-B909-49CEDE0101DC" dmnElementRef="_1929CBD5-40E0-442D-B909-49CEDE0101DC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="708" y="350" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_4055D956-1C47-479C-B3F4-BAEB61F1C929" dmnElementRef="_4055D956-1C47-479C-B3F4-BAEB61F1C929" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="709" y="210" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_1F9350D7-146D-46F1-85D8-15B5B68AF22A" dmnElementRef="_1F9350D7-146D-46F1-85D8-15B5B68AF22A" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="369" y="344" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_8A408366-D8E9-4626-ABF3-5F69AA01F880" dmnElementRef="_8A408366-D8E9-4626-ABF3-5F69AA01F880" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="534" y="83" width="133" height="63"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_800A3BBB-90A3-4D9D-BA5E-A311DED0134F" dmnElementRef="_800A3BBB-90A3-4D9D-BA5E-A311DED0134F">
+        <di:waypoint x="758" y="375"/>
+        <di:waypoint x="759" y="235"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_982211B1-5246-49CD-BE85-3211F71253CF" dmnElementRef="_982211B1-5246-49CD-BE85-3211F71253CF">
+        <di:waypoint x="419" y="369"/>
+        <di:waypoint x="600.5" y="114.5"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_AEC4AA5F-50C3-4FED-A0C2-261F90290731" dmnElementRef="_AEC4AA5F-50C3-4FED-A0C2-261F90290731">
+        <di:waypoint x="759" y="235"/>
+        <di:waypoint x="600.5" y="114.5"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/abigone.dmn
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/abigone.dmn
@@ -1,0 +1,1279 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.trisotech.com/dmn/definitions/_b03f43ec-3c2d-4731-960e-c662e05fbeba" id="_b03f43ec-3c2d-4731-960e-c662e05fbeba" namespace="http://www.trisotech.com/dmn/definitions/_b03f43ec-3c2d-4731-960e-c662e05fbeba"          exporter="DMN Modeler" exporterVersion="6.1.16" name="abigone" triso:logoChoice="Default">
+    <semantic:extensionElements/>
+    <semantic:decision id="_5cbd1fc5-a77d-47d7-9a45-1974169e34e2" name="rootDecision">
+        <semantic:variable name="rootDecision" id="_cda2cf2a-2182-4135-b892-2e9e5e757c4c" typeRef="boolean"/>
+        <semantic:informationRequirement id="_83ae5e53-9aae-4201-b812-9ba1a8f81d84">
+            <semantic:requiredDecision href="#_b7e17303-bce1-4514-8abd-6f4823fe0b01"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_fa77c86e-d47a-4e85-bbeb-ade6c0f7d0f2">
+            <semantic:requiredDecision href="#_bbdc4467-2420-440b-a77e-d85bff1d24d6"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_c4825670-f4e5-4002-bdf1-44016f593c4c">
+            <semantic:requiredDecision href="#_b969722d-7c7f-4a97-beea-0b2b783116dd"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_d4dea5de-0b45-40e1-a4e6-953d84afa10f">
+            <semantic:requiredDecision href="#_4480501d-5f0d-4013-8842-8b49d1872c25"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_0f91cfbd-5cbc-4a18-a515-322075c8b046">
+            <semantic:requiredDecision href="#_6f219e11-5da1-4292-917c-7dfb8def5772"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_bc09cf42-e99e-4dd5-90bc-a59044ddf716">
+            <semantic:requiredDecision href="#_319c5c32-fe02-4c62-a923-af936229e1f0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_131fcb62-28b4-4e17-b02f-7e8d89c5f405">
+            <semantic:requiredDecision href="#_94466fef-c73e-4815-ad42-840466dc3373"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_dc8cf81a-b878-4077-af36-0b1c33986242">
+            <semantic:requiredDecision href="#_331d8f48-c132-4680-a734-4b9fc25c14a0"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_1824f99b-ea87-4683-9905-e9fc14afcd31">
+            <semantic:requiredDecision href="#_fb5da915-9486-4900-b19a-f99d65393c2f"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_a543af9b-e89c-4124-9e81-0130b6085436">
+            <semantic:requiredDecision href="#_6047feca-73d0-445f-868e-bb801b31a7a3"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_f4f546b6-f8a8-4217-8278-4112be89129a" hitPolicy="ANY" outputLabel="rootDecision" typeRef="boolean" triso:expressionId="_900781a5-0257-4f34-b33f-597c8e634360">
+            <semantic:input id="_287a80ec-afde-4cec-9134-712c49c16961">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_2</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_2f41836d-1b5b-46b3-9bdf-98315a240f8c">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_4</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_1067f32b-3ae8-4179-930c-339fc6bd2afe">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_6</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_49db7750-5024-4018-bb03-acff61977fdb">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_8</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_ee1d9730-269e-4895-acd4-5c04ad8ac407">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_10</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_63e6cf51-9fc7-44dd-aa27-6a7f3fea6cf2">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_12</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_66d6f939-bbd3-4737-b2b2-dd4ea09f2c3f">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_14</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_a55e36ff-07d6-4e04-9303-dc819a849d6a">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_16</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_eaa3698f-1f33-484e-a4f1-b255613b2441">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_18</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:input id="_4c2d12f5-fa58-40b2-a36a-7c8812a35930">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_20</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_d9536443-cdee-4246-af5d-9f373a42b785"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_9264b509-0cc7-455d-9901-e200774bf663">
+                <semantic:inputEntry id="_9a6bc89e-4b6c-4910-9ac1-544a9385c5ee">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_6e833b94-1224-461c-bb44-aa83a24dcbc7">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_79390d37-c898-4a58-b7e3-b5dd2cc7480c">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_f93e60ce-82c8-4812-a088-8f3c927aec12">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_c581870b-4be1-4dce-8da3-93a4286f2297">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_02d57b14-0ae9-4f83-90b0-28c70ea87232">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_40573af7-eecb-4e8e-a490-b1c84ef988b7">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_26da62de-1ff0-4947-afec-ed03e33a2f2d">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_3316d165-1d7e-4fd6-8de0-fc958ba39203">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_85226785-a7e1-4abe-aa62-6f93f29915d9">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_52ccf5cf-92ca-47b2-a4d3-25d2fcc7563d">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_7fe95e50-1332-435b-beb2-42d4ffb7d85f">
+                <semantic:inputEntry id="_c1bd6cd3-b76e-429f-933e-b11d969803b4">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_8efd2121-c4a1-40d4-9776-4cad5e7435fb">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_6dcb0a6a-6f7d-4eea-a2e9-22dca0d1061e">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_1652e92a-561f-4a49-986c-e49aac407b35">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_6cc18fce-d387-480c-917b-ae47f8538826">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_794a30c3-342c-42af-8a72-84ad04f4529a">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_b00d6450-1364-4f71-a309-83c746af2541">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_701ff6f3-1974-4dba-b7d1-3c17a56b7c77">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_eebe2518-1008-4f18-8594-7a589dbb8876">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_5a45e842-e808-4fa4-927f-513db82c987d">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_1e72d5f0-e3cc-4faf-8c06-79516284c21c">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_8f6ebf97-7326-495b-8da9-c9311785362d" name="input_1">
+        <semantic:variable name="input_1" id="_b5b8646c-8d39-48bd-9db4-e93838b0faf1" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_b7e17303-bce1-4514-8abd-6f4823fe0b01" name="decision_2">
+        <semantic:variable name="decision_2" id="_33c66e01-3956-43b1-aa06-3eb87b446b07" typeRef="boolean"/>
+        <semantic:informationRequirement id="_4642ded7-90d4-4781-bde2-02b5282d3860">
+            <semantic:requiredDecision href="#_3f07d906-91ac-45bb-8aad-b80969e8af6f"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_4a73f25b-6969-47cb-82bc-37c22db7fd14" hitPolicy="UNIQUE" outputLabel="decision_2" typeRef="boolean" triso:expressionId="_ddd57635-9e9b-4284-9986-af979b35c4ad">
+            <semantic:input id="_7a6e3ad8-064f-4fad-bca3-1dec68b42d01">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_1</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_64c32a8b-7bf6-43bb-b522-d31f5f87b3a8"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_1031b5f8-c0de-4651-a1a7-2798c99f3101">
+                <semantic:inputEntry id="_b8b3083d-1077-483f-bd0b-f871909ff171">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_02e5e724-5639-4666-9729-81730cf0f5dd">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_cac794de-976d-47d1-8a3c-be8e80e272da">
+                <semantic:inputEntry id="_e811eb17-231f-4a6a-8db2-c7a9cd89225d">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_a621a729-398d-4a49-94cc-a9964a4e54c2">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_b8473d14-d3f3-44f4-99d5-ce325749968d" name="input_2">
+        <semantic:variable name="input_2" id="_335d60b7-9551-467c-af79-d93992c5ad98" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_bbdc4467-2420-440b-a77e-d85bff1d24d6" name="decision_4">
+        <semantic:variable name="decision_4" id="_d2815234-3be6-43ae-a6e2-7c2af04771f7" typeRef="boolean"/>
+        <semantic:informationRequirement id="_5571372c-0907-44bb-b8c8-c72685c3bae5">
+            <semantic:requiredDecision href="#_5b221de8-9088-4699-a81e-97c93558f369"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_53c348e6-1cfd-427e-be0c-e4bd53155270" hitPolicy="UNIQUE" outputLabel="decision_4" typeRef="boolean" triso:expressionId="_4995c5e4-6f2a-47fd-86c8-1d99a22e59a7">
+            <semantic:input id="_9832ee09-7040-4d6e-831b-bcf3d95b26af">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_3</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_46659b1d-0196-4167-a24d-9377be807257"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_e14b9a35-b47a-4fde-92de-f26b3765d79f">
+                <semantic:inputEntry id="_dc5dff1e-5fd7-48dc-9f07-85e28c4d1ade">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_7c4ac4fd-f79d-48cd-8def-e9be97829fd0">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_bf644eed-073b-491f-b8fb-0120a3ab4262">
+                <semantic:inputEntry id="_bb104ce0-5ea0-4ae1-9013-28f6a871a3eb">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_bdab0c14-d8e6-479c-acd1-11d3436dc4c7">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_84b5c7cc-f815-45f9-96aa-dad43943d62f" name="input_3">
+        <semantic:variable name="input_3" id="_e75f7f0e-a51f-48d3-957c-6abdea964818" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_b969722d-7c7f-4a97-beea-0b2b783116dd" name="decision_6">
+        <semantic:variable name="decision_6" id="_06049685-0a74-47d8-afb7-b832fc091e9f" typeRef="boolean"/>
+        <semantic:informationRequirement id="_8463dd83-3fd9-4f4e-9e7d-c7128813d564">
+            <semantic:requiredDecision href="#_460151cb-0a4c-48b7-8c42-ac285dfe93fc"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_ca0bd3aa-dd52-4e82-b851-8b055f52e5a1" hitPolicy="UNIQUE" outputLabel="decision_6" typeRef="boolean" triso:expressionId="_c80759d0-4430-494e-b4b4-7b318697cb20">
+            <semantic:input id="_198d77aa-0cc9-4f96-a44b-ef9554a51c23">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_5</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_78c61d21-2d23-4bd9-baec-f55fc3b253dd"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_742807f5-e6f0-4c8c-80a4-964a863ee2a3">
+                <semantic:inputEntry id="_f4f47ac6-558a-4da0-b737-ae8ea97f0a29">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_6918d6c1-cb05-4853-a387-168553f06e2a">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_4dca4164-56a7-4c65-89ae-e5024ad43866">
+                <semantic:inputEntry id="_76dc4928-978c-4e25-80bf-3a848a1befda">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_762b4bf7-0fe6-4c11-a1a9-2551776e1236">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_330d5193-46ba-4c36-9306-fd7c8a24c071" name="input_4">
+        <semantic:variable name="input_4" id="_bb3585b9-b50e-4d87-97c8-8df1ed3d49ca" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_4480501d-5f0d-4013-8842-8b49d1872c25" name="decision_8">
+        <semantic:variable name="decision_8" id="_a309a5b0-6c65-475c-9b75-976006fbd3d0" typeRef="boolean"/>
+        <semantic:informationRequirement id="_5e1f2e1d-b672-4e36-9566-ac62b1c2095f">
+            <semantic:requiredDecision href="#_25355a1e-fd01-44ad-9851-e1df40a5a91f"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_593c72f9-e5a8-4600-8219-83b1f198ec20" hitPolicy="UNIQUE" outputLabel="decision_8" typeRef="boolean" triso:expressionId="_65d00b7a-4d35-4705-a05c-d4a94c34dc6d">
+            <semantic:input id="_71af8aa5-1e55-417c-8315-049a6f948096">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_7</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_65a7bd27-c391-4ffe-9592-fd195787cced"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_c5f898a9-f1c7-4761-85ad-f6cdd0b8ca68">
+                <semantic:inputEntry id="_98e04bc2-2c3b-48cb-b536-3bb0b4afb917">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_7dc8be49-faa7-4f8b-85f6-d97d9b5d40dc">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_91fe585a-7db0-4f86-aae0-f075595dde0d">
+                <semantic:inputEntry id="_33683212-9eac-47fa-a6c6-abb3f208f4dd">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_1359cea9-9352-431f-b89b-87dca363dc23">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_bdeef74a-fc1c-4543-a1cb-332d345f8a82" name="input_5">
+        <semantic:variable name="input_5" id="_8cb655eb-a9e3-4945-9ab8-04e60041bdb6" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_6f219e11-5da1-4292-917c-7dfb8def5772" name="decision_10">
+        <semantic:variable name="decision_10" id="_26badf2b-286f-4782-b086-fcc6b4f987b8" typeRef="boolean"/>
+        <semantic:informationRequirement id="_569eaf7e-4fe2-460b-baf9-83517f80a729">
+            <semantic:requiredDecision href="#_be1f14b9-e86a-4da5-8642-e7de4aba589d"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_a383d7fb-6524-4304-aac9-06a2d1355f4d" hitPolicy="UNIQUE" outputLabel="decision_10" typeRef="boolean" triso:expressionId="_4d8abf2a-91e1-4487-a3a5-e38b99f049c5">
+            <semantic:input id="_ebe95460-3e61-4fcc-85ef-cc2c91d04973">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_9</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_c3a54b13-2807-4f8b-8967-5cb2bec745d2"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_ae6d38ad-94a4-4949-8b29-878ad3735182">
+                <semantic:inputEntry id="_04f16ad5-4203-463e-a207-bbde19e430b8">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_a5f8e639-3ee0-4e82-bbcf-5edd89a9072f">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_ef721bc3-9b75-4485-a356-50c83219fe46">
+                <semantic:inputEntry id="_207e4309-7fa2-47ff-8a6e-c9a7f601680c">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_2b1e4eba-20af-4e40-9835-24368c6f20b4">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_7ced22af-88d6-49a8-b1c5-a97af37c87c3" name="input_6">
+        <semantic:variable name="input_6" id="_9f27eb82-7a08-49d3-a906-a5735a6e78d9" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_319c5c32-fe02-4c62-a923-af936229e1f0" name="decision_12">
+        <semantic:variable name="decision_12" id="_69a1cf22-fc56-42a5-8219-d3b2b366669e" typeRef="boolean"/>
+        <semantic:informationRequirement id="_3afe161e-a492-481d-baa1-b8a62cf7592c">
+            <semantic:requiredDecision href="#_118e64ca-f13c-481e-ade9-bd37edd91939"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_5c88fb5e-7212-4fab-b4af-27474bf61af9" hitPolicy="UNIQUE" outputLabel="decision_12" typeRef="boolean" triso:expressionId="_930323e0-658b-440e-bde4-bb169f8e5200">
+            <semantic:input id="_ef2d80b4-598f-4633-a854-a9ce4aa59deb">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_11</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_7e9d7ddc-37c9-4895-90ac-f903e0ee019b"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_2e3d54ba-c062-49b8-a8fa-19f5e8882e42">
+                <semantic:inputEntry id="_de941475-c4a4-4330-b366-b2161066a2b2">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4b693ee3-86d6-4e0e-bc54-ab80f48aea67">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_559ebb7e-bfb1-4d9f-ab03-684179c1079b">
+                <semantic:inputEntry id="_8275c412-4a11-4eb6-836c-00ef795ad0fe">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_299bf45c-8f9c-4e9b-93f6-0e27f5b1d51a">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_3cd1c910-d789-487b-9a04-ce32702f0c59" name="input_7">
+        <semantic:variable name="input_7" id="_a8e584a9-d9d0-4927-9818-36e66f591879" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_94466fef-c73e-4815-ad42-840466dc3373" name="decision_14">
+        <semantic:variable name="decision_14" id="_ac87858d-b918-4390-b6b8-6077ad8ffd97" typeRef="boolean"/>
+        <semantic:informationRequirement id="_d0c3e051-2b53-4def-badd-896b4f034c5a">
+            <semantic:requiredDecision href="#_66d32ef7-19c8-4fe4-b229-ef00493ecf10"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_374a1838-e690-414b-adb6-2ca6d04fc103" hitPolicy="UNIQUE" outputLabel="decision_14" typeRef="boolean" triso:expressionId="_5f429b03-2078-4edc-a359-020d3624f5f2">
+            <semantic:input id="_481f9695-fff4-405f-bebf-6799d720152a">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_13</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_ffd1e30b-f37e-42f2-9414-c2d8a6f95ce3"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_6e2a33c5-5d97-40d5-bd8a-ba731a4840dc">
+                <semantic:inputEntry id="_b130b47a-523c-41f2-bdcf-80df1a1ca9ea">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_7a6c4af0-e239-42f6-9fbf-d23f5b5cc4d5">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_05131641-8657-459a-8d53-7b148e2801e7">
+                <semantic:inputEntry id="_d063d3b4-3950-4000-97ed-a4aa2600d7ad">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_88c52c2b-541f-4315-aa05-4304ceb05ceb">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_b0b3cd4d-c445-4705-b38d-d589c790434b" name="input_8">
+        <semantic:variable name="input_8" id="_486fa8ad-d7e8-456b-9a71-9203e69f3938" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_331d8f48-c132-4680-a734-4b9fc25c14a0" name="decision_16">
+        <semantic:variable name="decision_16" id="_2c417ae0-172c-481f-a97d-5a165ebaa8b7" typeRef="boolean"/>
+        <semantic:informationRequirement id="_dad1ba25-4093-49f9-a93e-1857e2e387c0">
+            <semantic:requiredDecision href="#_735aca0f-d4ce-41ac-9c15-b0cf5a0b4b77"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_63d9fc14-3ce2-4b45-9ac3-a5b48d9371cb" hitPolicy="UNIQUE" outputLabel="decision_16" typeRef="boolean" triso:expressionId="_a9abd234-d359-45ca-b2a5-a79cfa4b6dfc">
+            <semantic:input id="_48ad2880-2db8-404c-8b41-4bc798be3e72">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_15</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_f76fc915-c2fe-4364-b187-901d9868f41e"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_46dbb895-5dd3-49f4-9713-1ca97e86b511">
+                <semantic:inputEntry id="_7b39f4d6-314d-4df7-aa89-d1c4474423e4">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4e29f335-43fe-467a-a668-4665286ba96d">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_ce27050c-7392-4e21-b9e7-86963df41a89">
+                <semantic:inputEntry id="_14f0c296-bd25-4c96-a5ae-be40d2851253">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_15806fe4-27b1-4d11-8f70-4d68c6f1e4da">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_553ff38f-24fe-4722-97d5-908e9d55754c" name="input_9">
+        <semantic:variable name="input_9" id="_f49dd097-a20c-4e56-bdef-1795315b3ef7" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_fb5da915-9486-4900-b19a-f99d65393c2f" name="decision_18">
+        <semantic:variable name="decision_18" id="_f213a197-ccba-45cd-a916-b59a112ee004" typeRef="boolean"/>
+        <semantic:informationRequirement id="_459ec31b-76b0-4d2c-ad16-c4e0389e890e">
+            <semantic:requiredDecision href="#_87ba2d02-3099-4dfd-a996-b0d77eeffb02"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_a3bca702-4b34-46e5-b778-0168730d55ee" hitPolicy="UNIQUE" outputLabel="decision_18" typeRef="boolean" triso:expressionId="_c776e839-fdf1-4760-b031-1edce8183e20">
+            <semantic:input id="_b9243737-8149-4359-82ff-79ae16f18691">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_17</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_3d15af0b-8bae-4b05-a113-282f7db8ed59"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_644aac22-f008-4c9e-9643-dc79747f7d83">
+                <semantic:inputEntry id="_216f6fe7-e6ff-4fe8-9662-7fdd32015486">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4ff52d77-f444-4a5a-88b5-e6c86c04bd1b">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_32084e2e-f858-43d0-94bb-cbcaf24e6d4d">
+                <semantic:inputEntry id="_498d2c6d-80d0-40cb-82c1-ec98b8e3103e">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_6599a8b0-8a9b-42a5-9d9c-9c5137f0c1e8">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:inputData id="_ab855757-c6c0-4cb3-8fcf-6769630551cf" name="input_10">
+        <semantic:variable name="input_10" id="_04b88c1e-e74c-4cf1-aab1-88ddac31b703" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:decision id="_6047feca-73d0-445f-868e-bb801b31a7a3" name="decision_20">
+        <semantic:variable name="decision_20" id="_28654426-0f09-4d38-b99e-a9e247f9cdde" typeRef="boolean"/>
+        <semantic:informationRequirement id="_6f368a97-be69-4767-a3cd-63e319ddf8e1">
+            <semantic:requiredDecision href="#_3e568408-1217-44d7-bb5f-3ce36239cbb8"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_d150cc80-d945-4bd3-846d-2247a18feebd" hitPolicy="UNIQUE" outputLabel="decision_20" typeRef="boolean" triso:expressionId="_6bfc3fc9-07f7-4ff5-a69d-8a3101245880">
+            <semantic:input id="_de747b2a-32a1-4d1f-8a63-d2a29091863a">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>decision_19</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_098599fc-4897-40b7-b625-12610c583c33"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_5589bf04-7117-49a0-9b35-4326280462d0">
+                <semantic:inputEntry id="_f8ab3050-b9f5-405f-80e1-b840b9fbac55">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_bfb927ff-f825-4665-855a-6f58f894b7ff">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_48680701-dd8f-491e-8c90-8bbda24e7b4b">
+                <semantic:inputEntry id="_3c3c5623-ad7b-40be-94c0-32d067c44658">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_c8ffa24d-f080-477d-8cd5-6030c7690836">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_3f07d906-91ac-45bb-8aad-b80969e8af6f" name="decision_1">
+        <semantic:variable name="decision_1" id="_6a41acbd-2352-4182-b12f-167a3747da8e" typeRef="boolean"/>
+        <semantic:informationRequirement id="_1b1a7cc5-d537-4ae6-9625-3dac03df4482">
+            <semantic:requiredInput href="#_8f6ebf97-7326-495b-8da9-c9311785362d"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_a68f4742-a4d7-4ad6-ad3b-d9e8af324e99" hitPolicy="UNIQUE" outputLabel="decision_1" typeRef="boolean" triso:expressionId="_795bed6a-cb0f-4a62-bdfd-894af35c40f4">
+            <semantic:input id="_cec08a31-10b0-411b-a9b2-886307a08f48">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_1</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_dce20feb-b68e-4a84-ba90-2bf81b8df1d7"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_3dadc494-8e91-415a-a9d8-32834c7470a5">
+                <semantic:inputEntry id="_d1737b3b-489b-4764-a961-98b9f093978b">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_7f76db5b-8e50-4594-b359-424a33d3944a">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_4569446b-fac5-4d6c-81b9-5057c4b47cba">
+                <semantic:inputEntry id="_30c9d9ca-a429-4764-84e1-4b9725326338">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_4f203c73-e019-447f-a66d-615f964278eb">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_5b221de8-9088-4699-a81e-97c93558f369" name="decision_3">
+        <semantic:variable name="decision_3" id="_5b84899a-8c77-4855-befb-114430fce981" typeRef="boolean"/>
+        <semantic:informationRequirement id="_979e5ba6-ec36-46ea-ab12-8e660b9b5ec9">
+            <semantic:requiredInput href="#_b8473d14-d3f3-44f4-99d5-ce325749968d"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_22434a91-d059-43a8-b71d-4602d926895d" hitPolicy="UNIQUE" outputLabel="decision_3" typeRef="boolean" triso:expressionId="_5c8c56da-d69d-4c9c-bcff-aa768b75205d">
+            <semantic:input id="_52fc4865-f429-4c64-9a7a-d93bfe2be9a2">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_2</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_c337196d-c696-4b63-bbde-ac028d75aec1"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_21d21922-c393-4607-933d-197aa920d7fa">
+                <semantic:inputEntry id="_a800cb2e-b3a8-4e76-a807-28daf98b06f1">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_6c355da9-d10e-49a2-9027-1683effaed0f">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_f223eef7-a7fb-4fd9-9b23-2177fb86b4b7">
+                <semantic:inputEntry id="_c9d7a69a-238b-41ae-868e-c1f3f18d5a80">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_8a7826e4-4e61-418a-8da7-bb3ed1f346a5">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_460151cb-0a4c-48b7-8c42-ac285dfe93fc" name="decision_5">
+        <semantic:variable name="decision_5" id="_ab2dfeb3-a12d-4921-b5d6-c17df122792e" typeRef="boolean"/>
+        <semantic:informationRequirement id="_bfbcd1d2-033a-4cc8-8ebf-b4dfa1c60eca">
+            <semantic:requiredInput href="#_84b5c7cc-f815-45f9-96aa-dad43943d62f"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_fc9b8a85-9849-49b8-b65a-4b233230393c" hitPolicy="UNIQUE" outputLabel="decision_5" typeRef="boolean" triso:expressionId="_67e780e3-2399-498e-b03d-bd551cc0acee">
+            <semantic:input id="_16613c16-1daa-41ab-abf9-77b337486a41">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_3</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_b3eafc29-6f34-4b88-b5d3-24d7e36a0ffa"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_15a815f8-67b4-4873-9443-c01da0276f96">
+                <semantic:inputEntry id="_965471da-e261-4968-a6c3-0846650c2ce4">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_520efc83-958c-45c7-8794-42e735c4fe65">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_36a57136-f22d-4034-a778-ae3d90aa1be8">
+                <semantic:inputEntry id="_efbb7180-dbf1-497f-9f8a-9a4da3fc9eb4">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_d20ef6db-2a5c-4fd3-b661-12a8d23525e7">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_25355a1e-fd01-44ad-9851-e1df40a5a91f" name="decision_7">
+        <semantic:variable name="decision_7" id="_eb20be7f-ac2e-4f73-9808-1a4b0a73d6a7" typeRef="boolean"/>
+        <semantic:informationRequirement id="_88bcb617-61ee-4761-b0ba-ced0c11c7d99">
+            <semantic:requiredInput href="#_330d5193-46ba-4c36-9306-fd7c8a24c071"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_84528fa4-a716-4697-a2d3-f7f5415d724d" hitPolicy="UNIQUE" outputLabel="decision_7" typeRef="boolean" triso:expressionId="_e962f95c-2c83-46a2-9fb2-f7a6ee622fa1">
+            <semantic:input id="_cc853548-74f5-4434-be09-34a62d7b8df1">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_4</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_ad133cc0-c51a-4e64-9a2f-47138c6e4cf6"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_fb2d749c-646a-4848-a618-e06dd729f9e3">
+                <semantic:inputEntry id="_4e90b881-0908-4368-8823-a38dc35dd02b">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_024fb841-1403-4798-8a5d-199d39d6782c">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_8db63c82-c0fa-40c4-94c6-751601bdf39e">
+                <semantic:inputEntry id="_d3ddafdc-1c70-46b6-95c0-00b1c989f014">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_f44ee356-5731-46b7-84a8-2ca2d935230d">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_be1f14b9-e86a-4da5-8642-e7de4aba589d" name="decision_9">
+        <semantic:variable name="decision_9" id="_9a99e803-9d8e-4854-b9e0-117ce2d79fc7" typeRef="boolean"/>
+        <semantic:informationRequirement id="_0d4b2051-ba6d-47cb-8adc-cf4a002166b7">
+            <semantic:requiredInput href="#_bdeef74a-fc1c-4543-a1cb-332d345f8a82"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_05a43ee1-8663-49f0-a2d0-f375d3ac5cac" hitPolicy="UNIQUE" outputLabel="decision_9" typeRef="boolean" triso:expressionId="_09de477f-3f65-4fa7-a115-78810b9c9874">
+            <semantic:input id="_ca266c5c-2012-4f65-ba73-6951d2ba760e">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_5</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_1ebbabfa-20ab-4845-a9bb-64368204ba0a"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_ef5cf7ae-16f9-4f0c-89f3-99b2346ff931">
+                <semantic:inputEntry id="_e3b78b19-0f34-4a26-b904-9293b8607a1e">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_852dcfa2-0ce9-41fc-a196-f6ff69ecccb2">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_f5646777-0332-4afd-8442-40ea4f86baf9">
+                <semantic:inputEntry id="_cf808e73-15fb-4af3-b528-0bac59924e4d">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_10cbddcb-c43c-473c-a911-22b1b1c1c83f">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_3e568408-1217-44d7-bb5f-3ce36239cbb8" name="decision_19">
+        <semantic:variable name="decision_19" id="_bbc5efc9-7a90-48d7-845e-bc30d3a80f96" typeRef="boolean"/>
+        <semantic:informationRequirement id="_8008f7d0-8f13-41c4-aa07-a5c538813073">
+            <semantic:requiredInput href="#_ab855757-c6c0-4cb3-8fcf-6769630551cf"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_9595817e-46c0-49cf-9e3c-b8df605df334" hitPolicy="UNIQUE" outputLabel="decision_19" typeRef="boolean" triso:expressionId="_8e6f8f97-551a-4d9d-9c81-af37241ea568">
+            <semantic:input id="_c6b027dc-e1d0-4824-a247-f77b293610ca">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_10</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_637119e4-5b0c-4362-ac35-f6e45de52394"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_4c107ad7-dba8-4c9c-88ec-2d33d7b80827">
+                <semantic:inputEntry id="_1dd746e4-2bb4-4a94-aeba-6e6c5d411a51">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_360d7892-d7d7-4b0a-a570-e15b82588b97">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_9e97c048-efb0-403d-b0c6-479377c7eab2">
+                <semantic:inputEntry id="_7f16cb8d-14bb-4b5a-ade6-a0dcd3ca3d97">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_2330c2b8-0bbd-412c-ba0c-4a5b3beb9d31">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_87ba2d02-3099-4dfd-a996-b0d77eeffb02" name="decision_17">
+        <semantic:variable name="decision_17" id="_a521a848-b5bb-4500-8e11-5edaba9de1cc" typeRef="boolean"/>
+        <semantic:informationRequirement id="_c1c88621-79be-4eeb-8740-433412bd2e3f">
+            <semantic:requiredInput href="#_553ff38f-24fe-4722-97d5-908e9d55754c"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_8468f78e-1e74-4004-9ac7-d5cb761751e5" hitPolicy="UNIQUE" outputLabel="decision_17" typeRef="boolean" triso:expressionId="_2daacf3b-fb9e-4106-bed9-7337920a7ca2">
+            <semantic:input id="_bd0707e8-a4fb-4b7b-9a99-055dbe8949ac">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_9</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_24a03e4e-69d2-4b76-8c89-69804ba68bc8"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_74ad261c-f847-448f-bba2-a8a43e35e3db">
+                <semantic:inputEntry id="_ba88197d-abe5-4f61-8ef9-a83eb7e2347a">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_5fde32e4-5833-45c4-9ee9-bd5034548722">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_aa29e78f-3489-4666-8b63-8aecb947b2dc">
+                <semantic:inputEntry id="_6b32acd3-0985-43da-99cc-7f5a2d5b66a5">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_d2c660fc-4568-46e5-8e7a-65483b278c3c">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_735aca0f-d4ce-41ac-9c15-b0cf5a0b4b77" name="decision_15">
+        <semantic:variable name="decision_15" id="_3780f598-8cc2-4512-95c0-95e5236b6efc" typeRef="boolean"/>
+        <semantic:informationRequirement id="_57254d17-d213-4dff-a399-ce12f05a2a13">
+            <semantic:requiredInput href="#_b0b3cd4d-c445-4705-b38d-d589c790434b"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_75f138e5-b513-4cb6-8660-82aa306f9a46" hitPolicy="UNIQUE" outputLabel="decision_15" typeRef="boolean" triso:expressionId="_6f869444-323e-4f4d-81a9-67e40aadef95">
+            <semantic:input id="_2d20cad4-9744-400c-b5af-1a119b76b3b8">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_8</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_42904f18-f2dc-4d1b-9858-37d6690139da"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_5ec92c37-d2f5-4aa8-8df5-3041fd909e57">
+                <semantic:inputEntry id="_10b3128b-8e65-4106-8f3c-1f416ac8396f">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_b278b6d8-c25f-4ade-a9e8-f067b3e9950d">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_7d0ad951-1a3d-445e-9e90-864e40ec8f58">
+                <semantic:inputEntry id="_e7301d6f-617d-4912-b4dd-9a181447aac6">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_ab6dbc21-cf3f-4dab-8781-160828388f49">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_66d32ef7-19c8-4fe4-b229-ef00493ecf10" name="decision_13">
+        <semantic:variable name="decision_13" id="_958f75b3-d315-4208-bb19-b5d3e60a2271" typeRef="boolean"/>
+        <semantic:informationRequirement id="_c92c27d0-d54a-40b0-b0fb-9f9dab711342">
+            <semantic:requiredInput href="#_3cd1c910-d789-487b-9a04-ce32702f0c59"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_cb675085-5d33-40d5-89a1-6007c98cbd13" hitPolicy="UNIQUE" outputLabel="decision_13" typeRef="boolean" triso:expressionId="_99692a44-d3c5-4c6b-854e-6e77803cd3f2">
+            <semantic:input id="_3af27f38-bde7-4995-8c35-309c27c0e96f">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_7</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_89d476b2-fa81-45c7-84d2-395a019278f8"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_5a9ad5d3-11ed-4557-b294-b273f545fbdb">
+                <semantic:inputEntry id="_b8018371-ac9d-4dcb-a628-6f2afc17b8e1">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_e54db38b-7a70-4cd2-ae86-138ecb1eba18">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_1ba40401-adeb-4bc4-a69a-116bbbe19bc1">
+                <semantic:inputEntry id="_34ff8966-2673-458b-92f7-6c7a340d9835">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_25eed3cc-e56a-4b23-b9a1-31899b5e6fa7">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="_118e64ca-f13c-481e-ade9-bd37edd91939" name="decision_11">
+        <semantic:variable name="decision_11" id="_e67eab7a-ffd3-4ad2-a3c3-fa3b1336e81b" typeRef="boolean"/>
+        <semantic:informationRequirement id="_1b5951c6-16ef-4874-8384-fb2b711cdf7b">
+            <semantic:requiredInput href="#_7ced22af-88d6-49a8-b1c5-a97af37c87c3"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_3a986ebe-52e6-4b39-ada3-6e649ce7e160" hitPolicy="UNIQUE" outputLabel="decision_11" typeRef="boolean" triso:expressionId="_1b2258a1-a2ae-40c8-b73b-7d62f80f912c">
+            <semantic:input id="_88dceb60-8e69-461b-9dbd-5864c2b15591">
+                <semantic:inputExpression typeRef="boolean">
+                    <semantic:text>input_6</semantic:text>
+                </semantic:inputExpression>
+            </semantic:input>
+            <semantic:output id="_5a59441b-1115-4cc8-96c4-4997bfa89673"/>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_00c8a29f-dfb1-4786-9cd2-3a358cf32d36">
+                <semantic:inputEntry id="_3c8543ca-3438-43e0-a66b-f0df840990c7">
+                    <semantic:text>true</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_c6fbc028-4741-4046-a96b-ae609a65aeda">
+                    <semantic:text>true</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_cc8112ab-b834-415b-97dc-d3fa3de63ff3">
+                <semantic:inputEntry id="_a0ea45c8-fa05-4b5a-a700-80755ed41bc1">
+                    <semantic:text>false</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_c82e6b1d-4160-4623-8183-f1231a042b7f">
+                    <semantic:text>false</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_74b4bcd8-3a38-48e3-adeb-fff6504bb43c" name="Page 1">
+            <dmndi:Size height="1050" width="2484.4823417663574"/>
+            <dmndi:DMNShape id="_79d611fe-2028-499c-8d22-35b7920c7801" dmnElementRef="_5cbd1fc5-a77d-47d7-9a45-1974169e34e2">
+                <dc:Bounds x="945" y="90" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="948" y="114"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_70e1f52a-e4cf-4afe-96d9-f17308dd7af0" dmnElementRef="_8f6ebf97-7326-495b-8da9-c9311785362d">
+                <dc:Bounds x="953.7588291168213" y="444" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="94" x="972.9968013763428" y="467"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6ed2fe6b-2c0b-4efd-8ae6-661eb0ff0a47" dmnElementRef="_b7e17303-bce1-4514-8abd-6f4823fe0b01">
+                <dc:Bounds x="945" y="214" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="948" y="238"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_b332c052-9061-41b9-99b7-9846e4a004d4" dmnElementRef="_bbdc4467-2420-440b-a77e-d85bff1d24d6">
+                <dc:Bounds x="1144.5" y="214" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1147.0064935064936" y="237.50819672131146"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_59090fb9-9acf-41d1-9ee2-882a45b480bd" dmnElementRef="_b8473d14-d3f3-44f4-99d5-ce325749968d">
+                <dc:Bounds x="1153.2588291168213" y="444" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="1172.6717417473888" y="467.0000036875407"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d11a6325-ba1b-4fbf-91cf-b770731eb21c" dmnElementRef="_b969722d-7c7f-4a97-beea-0b2b783116dd">
+                <dc:Bounds x="1337.5" y="213.99999618530273" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1340.0064935064936" y="237.5081929066142"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_86fc9813-406f-45c9-898a-fd53f3cd939e" dmnElementRef="_84b5c7cc-f815-45f9-96aa-dad43943d62f">
+                <dc:Bounds x="1346.2588291168213" y="443.99999618530273" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="1365.6717417473888" y="466.99999987284343"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a69afd82-d51f-4858-aa87-56e239aefe63" dmnElementRef="_4480501d-5f0d-4013-8842-8b49d1872c25">
+                <dc:Bounds x="1526.5" y="213.99999237060547" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1529.0064935064936" y="237.50818909191693"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d447928a-8c6f-44fa-8eb0-1b929fa74992" dmnElementRef="_330d5193-46ba-4c36-9306-fd7c8a24c071">
+                <dc:Bounds x="1535.2588291168213" y="443.99999237060547" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="1554.6717417473888" y="466.99999605814617"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a06d45c3-1d15-4408-858c-dfff585b00d5" dmnElementRef="_6f219e11-5da1-4292-917c-7dfb8def5772">
+                <dc:Bounds x="1716.5" y="213.9999885559082" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1719.0064935064936" y="237.50818527721967"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_a5d5f7b0-c95d-438e-9f94-7dfc43e4aec8" dmnElementRef="_bdeef74a-fc1c-4543-a1cb-332d345f8a82">
+                <dc:Bounds x="1725.2588291168213" y="443.99997329711914" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="1744.6717417473888" y="466.99997698465984"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4fcb3da1-f4c1-4481-b7c1-770c501f2106" dmnElementRef="_319c5c32-fe02-4c62-a923-af936229e1f0">
+                <dc:Bounds x="766" y="213.99998474121094" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="768.5064935064935" y="237.5081814625224"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_064f8d9d-302d-4a94-b8a8-8118a59dca0e" dmnElementRef="_7ced22af-88d6-49a8-b1c5-a97af37c87c3">
+                <dc:Bounds x="774.7588291168213" y="443.99998474121094" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="794.1717417473886" y="466.99998842875164"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_60b74d43-7ae3-4564-a67f-b0d57eae2e6b" dmnElementRef="_94466fef-c73e-4815-ad42-840466dc3373">
+                <dc:Bounds x="581" y="213.99998092651367" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="583.5064935064935" y="237.50817764782514"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_f393d8cd-dc18-4413-9a52-b5ddd85f23cb" dmnElementRef="_3cd1c910-d789-487b-9a04-ce32702f0c59">
+                <dc:Bounds x="589.7588291168213" y="443.9999809265137" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="609.1717417473886" y="466.99998461405437"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_eb59c44e-ac43-4764-8743-465959e120fd" dmnElementRef="_331d8f48-c132-4680-a734-4b9fc25c14a0">
+                <dc:Bounds x="399" y="213.9999771118164" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="401.5064935064935" y="237.50817383312787"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2d326b81-fc08-43a6-89ef-74fa1cbbd860" dmnElementRef="_b0b3cd4d-c445-4705-b38d-d589c790434b">
+                <dc:Bounds x="407.7588291168213" y="443.9999771118164" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="427.17174174738864" y="466.9999807993571"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_9ee2284a-7b6c-4034-962d-77f2cf75f9d6" dmnElementRef="_fb5da915-9486-4900-b19a-f99d65393c2f">
+                <dc:Bounds x="218" y="213.99997329711914" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="220.50649350649348" y="237.5081700184306"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1731d267-ba3f-4c6b-9e58-d6b5f5a3eb99" dmnElementRef="_553ff38f-24fe-4722-97d5-908e9d55754c">
+                <dc:Bounds x="226.7588291168213" y="443.99997329711914" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="246.17174174738864" y="466.99997698465984"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_726869b4-89d7-4029-8520-ee6cbc2a13ed" dmnElementRef="_6047feca-73d0-445f-868e-bb801b31a7a3">
+                <dc:Bounds x="41" y="214" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="43.50649350649351" y="237.50819672131146"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_caa169f2-84cd-42c5-b1f8-06325c52f747" dmnElementRef="_ab855757-c6c0-4cb3-8fcf-6769630551cf">
+                <dc:Bounds x="49.75882911682129" y="444" width="135.48234176635742" height="60.00000762939453"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93.99999999999999" x="69.17174174738867" y="467.0000036875407"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_29251d6c-0195-4dea-8c23-bcf9f6fd08bd" dmnElementRef="_3f07d906-91ac-45bb-8aad-b80969e8af6f">
+                <dc:Bounds x="945" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="948" y="355"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_6701225d-5aa0-4e9f-8cb1-090c8beb6623" dmnElementRef="_5b221de8-9088-4699-a81e-97c93558f369">
+                <dc:Bounds x="1144.5" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="146" x="1147.5" y="355"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_be2917e1-a23b-4ea6-85af-060c2080b9f5" dmnElementRef="_460151cb-0a4c-48b7-8c42-ac285dfe93fc">
+                <dc:Bounds x="1337.5" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1340.0064935064936" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_99a14142-997f-4cf2-95bb-6d67365c041d" dmnElementRef="_25355a1e-fd01-44ad-9851-e1df40a5a91f">
+                <dc:Bounds x="1526.5" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1529.0064935064936" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_32f6332d-fe31-4495-a4ed-8a300ab777ac" dmnElementRef="_be1f14b9-e86a-4da5-8642-e7de4aba589d">
+                <dc:Bounds x="1716.5" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="1719.0064935064936" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_fd471545-7b20-4059-8bdb-e923c1bfbeea" dmnElementRef="_3e568408-1217-44d7-bb5f-3ce36239cbb8">
+                <dc:Bounds x="41" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="43.50649350649351" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_63100502-8a50-4d4a-acde-c4872a909fd6" dmnElementRef="_87ba2d02-3099-4dfd-a996-b0d77eeffb02">
+                <dc:Bounds x="218" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="220.50649350649348" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_34eebdc4-8677-4b99-8b9d-7dbaf2fa678b" dmnElementRef="_735aca0f-d4ce-41ac-9c15-b0cf5a0b4b77">
+                <dc:Bounds x="399" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="401.5064935064935" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_614137f3-2261-45fd-8b77-e7187c1ae4c5" dmnElementRef="_66d32ef7-19c8-4fe4-b229-ef00493ecf10">
+                <dc:Bounds x="581" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="583.5064935064935" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_294b52c8-7b2f-4d52-8da8-5d56cdd699a7" dmnElementRef="_118e64ca-f13c-481e-ade9-bd37edd91939">
+                <dc:Bounds x="766" y="331" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn" trisodmn:defaultBounds="true">
+                    <dc:Bounds height="12.000000000000004" width="146" x="768.5064935064935" y="354.5081967213115"/>
+                </dmndi:DMNLabel>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_e8896642-988d-4354-bdbf-7825b2315634" dmnElementRef="_83ae5e53-9aae-4201-b812-9ba1a8f81d84">
+                <di:waypoint x="1021.5" y="214"/>
+                <di:waypoint x="1021.5" y="150"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_7b40b2df-f3c1-4f58-bd46-c0fd97232cbc" dmnElementRef="_fa77c86e-d47a-4e85-bbeb-ade6c0f7d0f2">
+                <di:waypoint x="1271" y="214"/>
+                <di:waypoint x="1031.5" y="150"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_532d9836-c1fb-4f29-8320-96d9d7807193" dmnElementRef="_c4825670-f4e5-4002-bdf1-44016f593c4c">
+                <di:waypoint x="1364" y="213.99999618530273"/>
+                <di:waypoint x="1098" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_946c569d-2172-4f79-81e3-d2b7720ea1be" dmnElementRef="_d4dea5de-0b45-40e1-a4e6-953d84afa10f">
+                <di:waypoint x="1543" y="213.99999237060547"/>
+                <di:waypoint x="1098" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c7fcb649-4bf0-4aee-860a-1fe4a2315e46" dmnElementRef="_0f91cfbd-5cbc-4a18-a515-322075c8b046">
+                <di:waypoint x="1753" y="213.9999885559082"/>
+                <di:waypoint x="1098" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d7b8d373-a3e9-484c-837d-990792bc580b" dmnElementRef="_bc09cf42-e99e-4dd5-90bc-a59044ddf716">
+                <di:waypoint x="892.5" y="213.99998474121094"/>
+                <di:waypoint x="945" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0bccecd6-c8a6-410d-9e04-60fc3ee15416" dmnElementRef="_131fcb62-28b4-4e17-b02f-7e8d89c5f405">
+                <di:waypoint x="717.5" y="213.99998092651367"/>
+                <di:waypoint x="945" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1964ae6a-4e3b-4792-a9b0-1f8416243110" dmnElementRef="_dc8cf81a-b878-4077-af36-0b1c33986242">
+                <di:waypoint x="515.5" y="213.9999771118164"/>
+                <di:waypoint x="945" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9b91a06e-29f6-4e9e-bfb9-3d45edb096cf" dmnElementRef="_1824f99b-ea87-4683-9905-e9fc14afcd31">
+                <di:waypoint x="324.5" y="213.99997329711914"/>
+                <di:waypoint x="945" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_55434497-0b7e-4cd2-8ea7-90b6697220bf" dmnElementRef="_a543af9b-e89c-4124-9e81-0130b6085436">
+                <di:waypoint x="157.5" y="214"/>
+                <di:waypoint x="945" y="140"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d9566a0a-c37c-4984-b286-9ddee2fd3da2" dmnElementRef="_4642ded7-90d4-4781-bde2-02b5282d3860">
+                <di:waypoint x="1021.5" y="331"/>
+                <di:waypoint x="1021.5" y="274"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_68262825-d419-4328-8440-f427b3436101" dmnElementRef="_1b1a7cc5-d537-4ae6-9625-3dac03df4482">
+                <di:waypoint x="1021.4968013763428" y="444"/>
+                <di:waypoint x="1021.5" y="391"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca1ac537-03a3-4604-b64e-8d361442ac84" dmnElementRef="_5571372c-0907-44bb-b8c8-c72685c3bae5">
+                <di:waypoint x="1221" y="331"/>
+                <di:waypoint x="1221" y="274"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e98d6618-28b7-4ec4-9176-70bb71613e8b" dmnElementRef="_979e5ba6-ec36-46ea-ab12-8e660b9b5ec9">
+                <di:waypoint x="1220.9968013763428" y="444"/>
+                <di:waypoint x="1221" y="391"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4f0afbdd-5539-4e65-9835-8cec25856e88" dmnElementRef="_bfbcd1d2-033a-4cc8-8ebf-b4dfa1c60eca">
+                <di:waypoint x="1413.9968013763428" y="503.99999618530273"/>
+                <di:waypoint x="1414" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8615747b-3225-4996-a197-693c37636a2d" dmnElementRef="_8463dd83-3fd9-4f4e-9e7d-c7128813d564">
+                <di:waypoint x="1414" y="331"/>
+                <di:waypoint x="1414" y="273.99999618530273"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ca6b1045-bb86-471c-baee-f190c5798fd5" dmnElementRef="_88bcb617-61ee-4761-b0ba-ced0c11c7d99">
+                <di:waypoint x="1602.9968013763428" y="503.99999237060547"/>
+                <di:waypoint x="1603" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0f974193-5b0b-4acd-9497-26b6a2c4d4cc" dmnElementRef="_5e1f2e1d-b672-4e36-9566-ac62b1c2095f">
+                <di:waypoint x="1603" y="331"/>
+                <di:waypoint x="1603" y="273.99999237060547"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_edf75c11-c25c-4149-b30f-5b7ebe144676" dmnElementRef="_0d4b2051-ba6d-47cb-8adc-cf4a002166b7">
+                <di:waypoint x="1792.9968013763428" y="503.99997329711914"/>
+                <di:waypoint x="1793" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_8ecebf51-cb14-4bb8-b3e6-dc13d5a32beb" dmnElementRef="_569eaf7e-4fe2-460b-baf9-83517f80a729">
+                <di:waypoint x="1793" y="331"/>
+                <di:waypoint x="1793" y="273.9999885559082"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c6c942be-0d63-4949-8484-b270d88f422e" dmnElementRef="_1b5951c6-16ef-4874-8384-fb2b711cdf7b">
+                <di:waypoint x="842.4968013763428" y="503.99998474121094"/>
+                <di:waypoint x="842.5" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2d423fc5-f94e-40a6-9c35-533461540c3d" dmnElementRef="_c92c27d0-d54a-40b0-b0fb-9f9dab711342">
+                <di:waypoint x="657.4968013763428" y="503.9999809265137"/>
+                <di:waypoint x="657.5" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_41a9709c-0246-4ec2-8cb6-2467b32f2cad" dmnElementRef="_57254d17-d213-4dff-a399-ce12f05a2a13">
+                <di:waypoint x="475.4968013763428" y="503.9999771118164"/>
+                <di:waypoint x="475.5" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b98ddde0-8466-4438-9d4a-8fc347f07d8d" dmnElementRef="_c1c88621-79be-4eeb-8740-433412bd2e3f">
+                <di:waypoint x="294.4968013763428" y="503.99997329711914"/>
+                <di:waypoint x="294.5" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_2550bc88-8dad-40f5-b97f-1c34aea4985b" dmnElementRef="_8008f7d0-8f13-41c4-aa07-a5c538813073">
+                <di:waypoint x="117.49680137634277" y="504"/>
+                <di:waypoint x="117.5" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4f192aee-8fb9-4894-b725-f44c8f4f8147" dmnElementRef="_6f368a97-be69-4767-a3cd-63e319ddf8e1">
+                <di:waypoint x="117.5" y="331"/>
+                <di:waypoint x="117.5" y="274"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_65836572-8ace-481f-a3c3-43edc3485d1e" dmnElementRef="_459ec31b-76b0-4d2c-ad16-c4e0389e890e">
+                <di:waypoint x="294.5" y="331"/>
+                <di:waypoint x="294.5" y="273.99997329711914"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_661f81aa-5d70-463d-ac92-06e42ba1dd36" dmnElementRef="_dad1ba25-4093-49f9-a93e-1857e2e387c0">
+                <di:waypoint x="475.5" y="331"/>
+                <di:waypoint x="475.5" y="273.9999771118164"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_35b1ba8e-9322-40d0-92f0-d2605db283df" dmnElementRef="_d0c3e051-2b53-4def-badd-896b4f034c5a">
+                <di:waypoint x="657.5" y="331"/>
+                <di:waypoint x="657.5" y="273.9999809265137"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9fbfb579-aa7a-407f-a01a-4b1282e9fab7" dmnElementRef="_3afe161e-a492-481d-baa1-b8a62cf7592c">
+                <di:waypoint x="842.5" y="331"/>
+                <di:waypoint x="842.5" y="273.99998474121094"/>
+                <dmndi:DMNLabel sharedStyle="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_b03f43ec-3c2d-4731-960e-c662e05fbeba_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/ch11MODIFIED.dmn
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/dmn/ch11MODIFIED.dmn
@@ -1,0 +1,2094 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"
+                      xmlns:triso="http://www.trisotech.com/2015/triso/modeling"
+                      xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+                      xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+                      xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"
+                      xmlns="http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47" id="_3068644b-d2c7-4b81-ab9d-64f011f81f47"
+                      namespace="http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47" exporter="DMN Modeler" exporterVersion="6.1.5" name="DMN Specification Chapter 11 Example" triso:logoChoice="Default">
+    <semantic:extensionElements/>
+    <!-- this is an example from OMG's spec and has been modified in the Adjudication Decision decision logic to implement a FEEL literal expression decision logic instead. -->
+    <semantic:itemDefinition name="tEligibility" label="tEligibility" isCollection="false">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"INELIGIBLE", "ELIGIBLE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tBureauCallType" label="tBureauCallType" isCollection="false">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"FULL", "MINI", "NONE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tStrategy" label="tStrategy" isCollection="false">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE", "BUREAU", "THROUGH"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tRiskCategory" label="tRiskCategory" isCollection="false">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tRouting" label="tRouting" isCollection="false">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"DECLINE", "REFER", "ACCEPT"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tBureauData" label="tBureauData" isCollection="false">
+        <semantic:itemComponent name="CreditScore" id="_99719106-2967-461b-afc3-b7a339db2671" isCollection="false">
+            <semantic:typeRef>number</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="expression">
+                <semantic:text>[0..999], null</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="Bankrupt" id="_7936d6f5-9a13-4905-97be-6280d3d691ef" isCollection="false">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tApplicantData" label="tApplicantData" isCollection="false">
+        <semantic:itemComponent name="Monthly" id="_73204429-244f-48a6-9db6-24adc737d63a" isCollection="false">
+            <semantic:itemComponent name="Income" id="_167ba37f-60b2-4dd1-9840-2ee63435822c" isCollection="false">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent name="Expenses" id="_b20d29a9-645c-49ab-942f-58843f15385d" isCollection="false">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+            <semantic:itemComponent name="Repayments" id="_d307830e-9f74-4198-b7d0-d949a62bf012" isCollection="false">
+                <semantic:typeRef>number</semantic:typeRef>
+            </semantic:itemComponent>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="Age" id="_14f2fcdc-67d7-414b-9bfd-8f1590201532" isCollection="false">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="ExistingCustomer" id="_18a69a6f-9798-49ef-a84f-39299b87fade" isCollection="false">
+            <semantic:typeRef>boolean</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="MaritalStatus" id="_d5e789a7-865f-49f8-9c75-8c80c369192b" isCollection="false">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"S","M"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="EmploymentStatus" id="_a95b5d46-5c4e-45f9-8e7e-9f20ecea48df" isCollection="false">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"EMPLOYED","SELF-EMPLOYED","STUDENT","UNEMPLOYED"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tRequestedProduct" label="tRequestedProduct" isCollection="false">
+        <semantic:itemComponent name="ProductType" id="_ded04131-3e74-436b-a6c5-0de428f18b4d" isCollection="false">
+            <semantic:typeRef>string</semantic:typeRef>
+            <semantic:allowedValues triso:constraintsType="enumeration">
+                <semantic:text>"STANDARD LOAN","SPECIAL LOAN"</semantic:text>
+            </semantic:allowedValues>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="Amount" id="_f6e52ce4-bc92-46b7-acd3-fedf90685172" isCollection="false">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="Rate" id="_85be0fd1-37e5-4eae-b947-2d958823cb33" isCollection="false">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+        <semantic:itemComponent name="Term" id="_5bcf97b4-d04e-4bbf-81b9-2ed7b093aebc" isCollection="false">
+            <semantic:typeRef>number</semantic:typeRef>
+        </semantic:itemComponent>
+    </semantic:itemDefinition>
+    <semantic:itemDefinition name="tBureaucallType" label="tBureaucallType">
+        <semantic:typeRef>string</semantic:typeRef>
+        <semantic:allowedValues triso:constraintsType="enumeration">
+            <semantic:text>"FULL","MINI","NONE"</semantic:text>
+        </semantic:allowedValues>
+    </semantic:itemDefinition>
+    <semantic:decision id="d_BureauCallType" name="Bureau call type">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau Call Type &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Bureau call type &lt;/span&gt;table, passing the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau call type" id="_44344053-4779-4b6c-93ae-a59bfcf5ca28" typeRef="tBureauCallType"/>
+        <semantic:informationRequirement id="_27f91e41-4f06-46b4-974d-6ae45e8fcc68">
+            <semantic:requiredDecision href="#d_Pre-bureauRiskCategory"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="f648a91d-f751-47b8-a463-72d324575272">
+            <semantic:requiredKnowledge href="#b_BureauCallTypeTable"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_ac934f37-9880-4f48-8f4d-1454b64e953a" typeRef="tBureauCallType">
+            <semantic:literalExpression id="literal__ac934f37-9880-4f48-8f4d-1454b64e953a">
+                <semantic:text>Bureau call type table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_a8395946-f9e8-4051-851d-5ee276d6a442" name="Pre-Bureau Risk Category"/>
+                <semantic:literalExpression id="_ef1b9e7a-0538-4b43-b6a7-10b11afe8e43">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Strategy" name="Strategy">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Strategy &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, unique-hit decision table deriving Strategy from &lt;/span&gt;Eligibility and Bureau Call Type.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p align="LEFT"&gt;&amp;nbsp;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:question>Is credit bureau call required?</semantic:question>
+        <semantic:allowedAnswers>Yes (BUREAU) or No (DECLINE, THROUGH)</semantic:allowedAnswers>
+        <semantic:variable name="Strategy" id="_bdf5f692-6426-4779-a785-998f9a28db9a" typeRef="tStrategy"/>
+        <semantic:informationRequirement id="_25fc0e89-3b15-4227-9173-0cfed5d10f0c">
+            <semantic:requiredDecision href="#d_BureauCallType"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_68c00aa8-cd88-4898-a61e-c9dacbcdbd70">
+            <semantic:requiredDecision href="#d_Eligibility"/>
+        </semantic:informationRequirement>
+        <semantic:decisionTable id="_93360c6c-4bfd-444b-9be6-bc1d30c7be5c" hitPolicy="UNIQUE" outputLabel="Strategy" typeRef="tStrategy">
+            <semantic:input id="_fbcc6693-a068-4507-9339-e720bd7cb91c">
+                <semantic:inputExpression typeRef="tEligibility">
+                    <semantic:text>Eligibility</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"INELIGIBLE", "ELIGIBLE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:input id="_9647e22d-853c-44b9-9633-2a15c96c75d1">
+                <semantic:inputExpression typeRef="tBureauCallType">
+                    <semantic:text>Bureau call type</semantic:text>
+                </semantic:inputExpression>
+                <semantic:inputValues triso:constraintsType="enumeration">
+                    <semantic:text>"FULL", "MINI", "NONE"</semantic:text>
+                </semantic:inputValues>
+            </semantic:input>
+            <semantic:output id="_76d30497-9266-4b0b-9fb7-568cfb0e0eea">
+                <semantic:outputValues triso:constraintsType="enumeration">
+                    <semantic:text>"DECLINE", "BUREAU", "THROUGH"</semantic:text>
+                </semantic:outputValues>
+            </semantic:output>
+            <semantic:annotation name="Description"/>
+            <semantic:rule id="_3fa2ede6-28a1-480f-a334-ebedf6cfb926">
+                <semantic:inputEntry id="_c3acb66d-0372-4d10-a4a5-3afe94931bd3">
+                    <semantic:text>"INELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_dc1965fc-d6a7-4cf2-9c0e-7c10a1632333">
+                    <semantic:text>-</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_f0f1638c-904d-4fbb-9b5c-1205145c7f7b">
+                    <semantic:text>"DECLINE"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_febd6b8f-785b-4261-a871-73ddfeb03560">
+                <semantic:inputEntry id="_62d0a247-461f-41cf-8c29-cde2e158cfac">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_ee058f75-a8e3-4a9f-8a53-887801b12eab">
+                    <semantic:text>"FULL","MINI"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_49c8dead-6b83-4291-91d8-a7bb8d2c58dc">
+                    <semantic:text>"BUREAU"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+            <semantic:rule id="_e10de25e-4d0f-4681-b060-96249a56d2b2">
+                <semantic:inputEntry id="_ef8999f7-7f77-4254-b97d-04beec39223b">
+                    <semantic:text>"ELIGIBLE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:inputEntry id="_1dfdf459-a715-4b06-9c94-39d613a10dda">
+                    <semantic:text>"NONE"</semantic:text>
+                </semantic:inputEntry>
+                <semantic:outputEntry id="_85374875-0a6d-4189-b296-0f89ec8a77b3">
+                    <semantic:text>"THROUGH"</semantic:text>
+                </semantic:outputEntry>
+                <semantic:annotationEntry>
+                    <semantic:text></semantic:text>
+                </semantic:annotationEntry>
+            </semantic:rule>
+        </semantic:decisionTable>
+    </semantic:decision>
+    <semantic:decision id="d_Eligibility" name="Eligibility">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Eligibility rules business &lt;/span&gt;knowledge model, passing Applicant data.Age as the Age parameter, the output of the Pre-bureau risk category decision as the Pre-Bureau Risk Category parameter, and the output of the Pre-bureau affordability decision as the Pre-Bureau Affordability parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Eligibility" id="_337b7b94-0a1e-4386-a5bf-1148d27a5d54" typeRef="tEligibility"/>
+        <semantic:informationRequirement id="_44b4bed2-257c-4272-ac89-9adc628ed9c2">
+            <semantic:requiredDecision href="#d_Pre-bureauAffordability"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="e84f4293-9564-4806-ac95-c44db1e12129">
+            <semantic:requiredDecision href="#d_Pre-bureauRiskCategory"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_11982879-3f7f-4fd2-97c9-2f632bb7ee48">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_849a5e3b-a57b-4808-b37e-19266d92f99c">
+            <semantic:requiredKnowledge href="#b_EligibilityRules"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_5c0ba1db-d7de-4eb5-8859-96f008db51a7" typeRef="tEligibility">
+            <semantic:literalExpression id="literal__5c0ba1db-d7de-4eb5-8859-96f008db51a7">
+                <semantic:text>Eligibility rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_0a1efb39-760b-46da-8dd6-6b76492a5807" name="Age"/>
+                <semantic:literalExpression id="_03e8fa8a-cbd4-4d80-b9f0-24698f75c092">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_87537070-3f78-41d6-b48d-ca1c2d7be6fb" name="Pre-bureau Risk Category"/>
+                <semantic:literalExpression id="_172e34df-e46e-4cda-84c7-32f41e8a508d">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_22d61782-4dc3-4240-afbb-dbbaf331472b" name="Pre-bureau Affordability"/>
+                <semantic:literalExpression id="_d45730c2-44a6-4513-8cee-99bd9f132c36">
+                    <semantic:text>Pre-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Pre-bureauRiskCategory" name="Pre-bureau risk category">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the Prebureau&lt;/span&gt;risk category table business knowledge model, passing Applicant data . ExistingCustomer as the Existing Customer parameter and the output of the Application risk score decision as the Application Risk Score parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Pre-bureau risk category" id="_b320934f-014c-4f78-a5f5-c21b263d50e0" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_8f0f908c-60fa-4e69-8f4d-27bb44f11356">
+            <semantic:requiredDecision href="#d_ApplicationRiskScore"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_90bf8067-8ba9-4a89-95c4-f461736be09b">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_574df70d-4de6-401f-b467-1ae637317467">
+            <semantic:requiredKnowledge href="#b_Pre-bureauRiskCategoryTable"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_80fb4373-8a1b-4ad2-b711-8332067d3ae1" typeRef="tRiskCategory">
+            <semantic:literalExpression id="literal__80fb4373-8a1b-4ad2-b711-8332067d3ae1">
+                <semantic:text>Pre-bureau risk category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_7726c0fb-966d-4fcf-a376-53720ea07584" name="Existing Customer"/>
+                <semantic:literalExpression id="_36d148fb-2183-46d4-8030-89ec9d03bef1">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_50eca880-45e4-4f86-8e8c-6f9903120b95" name="Application Risk Score"/>
+                <semantic:literalExpression id="_2082f727-67d9-46a0-a933-08d2dbf49250">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Post-bureauRiskCategory" name="Post-bureau risk category">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-Bureau Risk Category &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logicv invokes the Postbureau &lt;/span&gt;risk category business knowledge model, passing Applicant data . ExistingCustomer as the Existing Customer parameter, Bureau data . CreditScore as the Credit Score parameter, and the output of the Application risk score decision as the Application Risk Score parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Credit Score parameter will be null.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Post-bureau risk category" id="_0959e324-1579-417f-a65f-7005e204be7a" typeRef="tRiskCategory"/>
+        <semantic:informationRequirement id="_690238e8-9d1a-4060-b9f1-7754124f0bbf">
+            <semantic:requiredDecision href="#d_ApplicationRiskScore"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_96de0bbf-d9a3-4b95-80c2-0ac6b4dc6a8a">
+            <semantic:requiredInput href="#i_BureauData"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_51c0f9a0-362e-43e0-add9-40c57432ab36">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="dafcb6b1-111b-416c-a031-d7c9d9a79d8e">
+            <semantic:requiredKnowledge href="#b_Post-bureauRiskCategoryTable"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_42651b68-aef4-42d3-a930-8f97ae4a9d81" typeRef="tRiskCategory">
+            <semantic:literalExpression id="literal__42651b68-aef4-42d3-a930-8f97ae4a9d81">
+                <semantic:text>Post-Bureau Risk Category table</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_782fdb99-e3bf-43b0-8c23-401d35f50588" name="Existing Customer"/>
+                <semantic:literalExpression id="_cffd4c8f-11ca-4229-b07e-742f3f779fdb">
+                    <semantic:text>Applicant data.ExistingCustomer</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_fe2d00a3-d9fa-4633-b413-4bb5ede89eb7" name="Credit Score"/>
+                <semantic:literalExpression id="_7e01e2bb-4a3f-459a-9a9c-2dfb77315282">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_e4b6ca3d-22af-483e-8cfe-1661889d1242" name="Application Risk Score"/>
+                <semantic:literalExpression id="_b0e3a383-77a6-42a0-b952-a03a514c7051">
+                    <semantic:text>Application risk score</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_ApplicationRiskScore" name="Application risk score">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application Risk Score &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Application &lt;/span&gt;risk score model business knowledge model, passing Applicant data . Age as the Age parameter, Applicant data . MaritalStatus as the Marital Status parameter and Applicant data . EmploymentStatus as the Employment Status parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Application risk score" id="_c5738036-b5ac-4133-9180-b048448165e2" typeRef="number"/>
+        <semantic:informationRequirement id="b8db8e29-b181-41c4-80d5-7ceaa8b5565d">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_9d683062-3860-4508-8827-3d7b71b315d0">
+            <semantic:requiredKnowledge href="#b_ApplicationRiskScoreModel"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_1f3b47e4-d00a-4300-956d-d58752335649" typeRef="number">
+            <semantic:literalExpression id="literal__1f3b47e4-d00a-4300-956d-d58752335649">
+                <semantic:text>Application risk score model</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_ff11233d-9915-4741-8d16-73bbbbd92d66" name="Age"/>
+                <semantic:literalExpression id="_fb87b21c-5e20-420a-8642-3318b3a1e117">
+                    <semantic:text>Applicant data.Age</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_6fe6555f-b856-44b9-945e-4e757dbdfae8" name="Marital Status"/>
+                <semantic:literalExpression id="_2c8fc186-8f1a-4f95-8e97-ace723770086">
+                    <semantic:text>Applicant data.MaritalStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_fd28e86b-b531-4df3-9791-2d43a4c5113a" name="Employment Status"/>
+                <semantic:literalExpression id="_e4422c9e-55f2-454d-b260-8541226d0e3f">
+                    <semantic:text>Applicant data.EmploymentStatus</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Pre-bureauAffordability" name="Pre-bureau affordability">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau Affordability &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;invokes the &lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Pre-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Pre-bureau affordability" id="_8e3b4356-76db-4a71-bd31-0510dc19e882" typeRef="boolean"/>
+        <semantic:informationRequirement id="_6b2fcd2c-3211-48c1-9937-705b38922963">
+            <semantic:requiredDecision href="#d_RequiredMonthlyInstallment"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_43edd81a-aed9-48ae-a1a7-644f528b8d3f">
+            <semantic:requiredDecision href="#d_Pre-bureauRiskCategory"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_77752640-b080-4145-8a46-c2df81174027">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="bfa6e573-f32a-49e7-8d2b-83552484035e">
+            <semantic:requiredKnowledge href="#b_AffordabilityCalculation"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_6c774a53-f3b7-44a7-8b4e-1c3795f02d02" typeRef="boolean">
+            <semantic:literalExpression id="literal__6c774a53-f3b7-44a7-8b4e-1c3795f02d02">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_077a377a-755f-480f-9f17-1c27ea119970" name="Monthly Income"/>
+                <semantic:literalExpression id="_0b26ff4b-f3b3-4182-a0e6-01566dd47143">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_3b357423-4413-4369-8b1b-2f224686be2e" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_019eb1ee-5fef-46d5-8850-0f13d6c663a7">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_dec38d22-29c2-412d-b2fe-f71c02db0609" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_4d4a4984-a67a-420d-8941-d240e1d6b0fd">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_1fd4b32a-9410-4001-a5ce-bd416c0e7e5a" name="Risk Category"/>
+                <semantic:literalExpression id="_30739d76-38f5-4c7e-837e-cc8f8ffccb28">
+                    <semantic:text>Pre-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_0fd0abb9-73ff-41a5-94c6-cca2e9d0513e" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_1591d3cf-e6cf-4bd0-81f7-0c16cb9352ea">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Post-bureauAffordability" name="Post-bureau affordability">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau affordability &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the &lt;/span&gt;Affordability calculation business knowledge model, passing Applicant data.Monthly.Income as the Monthly Income parameter, Applicant data.Monthly.Repayments as the Monthly Repayments parameter, Applicant data.Monthly.Expenses as the Monthly Expenses parameter, the output of the Post-bureau risk category decision as the Risk Category parameter, and the output of the Required monthly installment decision as the Required Monthly Installment parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Post-bureau affordability" id="_e1070450-0428-4900-9679-269abb3cbaad" typeRef="boolean"/>
+        <semantic:informationRequirement id="_0b4e7ee2-d280-4afe-8f70-1706662c9015">
+            <semantic:requiredDecision href="#d_RequiredMonthlyInstallment"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_257cab3f-11cc-4d9c-b904-2b1cf696c9c3">
+            <semantic:requiredDecision href="#d_Post-bureauRiskCategory"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_7385eb68-33e7-456b-8ba4-05a2ed13acdb">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="_6ab262b3-f743-4f8d-a2cb-88948f96f92c">
+            <semantic:requiredKnowledge href="#b_AffordabilityCalculation"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_3d37bd76-51df-475e-aa1e-cfb5081264c8" typeRef="boolean">
+            <semantic:literalExpression id="literal__3d37bd76-51df-475e-aa1e-cfb5081264c8">
+                <semantic:text>Affordability calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_b2f64319-da14-44de-a84c-1dfde0943dd8" name="Monthly Income"/>
+                <semantic:literalExpression id="_36bd9b24-dc1c-4073-898f-5f767ae469b7">
+                    <semantic:text>Applicant data.Monthly.Income</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_d2f25215-170d-467d-a87c-c61791b05cb1" name="Monthly Repayments"/>
+                <semantic:literalExpression id="_e962067e-8abb-4f07-9b30-aae4c29a56ce">
+                    <semantic:text>Applicant data.Monthly.Repayments</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_ffd507c1-0b7a-4cfa-ba8c-1cd96e0484f3" name="Monthly Expenses"/>
+                <semantic:literalExpression id="_d298b473-9190-4d3c-97e4-51a05e257573">
+                    <semantic:text>Applicant data.Monthly.Expenses</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_53d33b8d-bcc4-4f45-8766-8a9b474f2c05" name="Risk Category"/>
+                <semantic:literalExpression id="_d133fd26-8408-41e4-a0b4-a8341b15dbb7">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_023e84e9-a3a5-48f2-9872-6ce987d71b6b" name="Required Monthly Installment"/>
+                <semantic:literalExpression id="_7b5fd7bc-d224-43d6-9b76-a262bd557f48">
+                    <semantic:text>Required monthly installment</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_RequiredMonthlyInstallment" name="Required monthly installment">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Required monthly installment &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the &lt;/span&gt;Installment calculation business knowledge model, passing Requested product . ProductType as the Product Type parameter, Requested product . Rate as the Rate parameter, Requested product.Term as the Term parameter, and Requested product.Amount as the Amount parameter.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Required monthly installment" id="_9c6088c8-6fac-4327-a9ea-e4a83bd6c1ef" typeRef="number"/>
+        <semantic:informationRequirement id="e97efbf5-a718-44ac-a6fd-e8953a7a41fe">
+            <semantic:requiredInput href="#i_RequestedProduct"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="e144b843-7b9a-4525-b648-4f54aa3633c2">
+            <semantic:requiredKnowledge href="#b_InstallmentCalculation"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_2c0f8b7b-5166-4965-9257-fe1673c0a510" typeRef="number">
+            <semantic:literalExpression id="literal__2c0f8b7b-5166-4965-9257-fe1673c0a510">
+                <semantic:text>Installment calculation</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_d5db87c7-1c96-460b-b268-e5d009f3e684" name="Product Type"/>
+                <semantic:literalExpression id="_a28a434a-9034-40f6-a758-30bfcdd4b029">
+                    <semantic:text>Requested product.ProductType</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_7ba033bb-a30f-407e-b28a-96318b418e1e" name="Rate"/>
+                <semantic:literalExpression id="_13d9661d-b72a-4ec3-b8fa-1061405dbaf6">
+                    <semantic:text>Requested product.Rate</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_0c4e37c1-4cd6-4e74-9798-ceeb283b15f5" name="Term"/>
+                <semantic:literalExpression id="_dd2b9c06-9ddf-45a6-a841-8a3d0b76b9ea">
+                    <semantic:text>Requested product.Term</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_69c0fc0d-b047-4e8a-95fc-6be9bca85385" name="Amount"/>
+                <semantic:literalExpression id="_abce9d5b-aceb-4634-83ac-1e41d51a5bb9">
+                    <semantic:text>Requested product.Amount</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Routing" name="Routing">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic invokes the Routing rules business &lt;/span&gt;knowledge model, passing Bureau data . Bankrupt as the Bankrupt parameter, Bureau data . CreditScore as the Credit Score parameter, the output of the Post-bureau risk category decision as the Post-Bureau Risk Category parameter, and the output of the Post-bureau affordability decision as the Post-Bureau Affordability parameter. Note that if Bureau data is null (due to the THROUGH strategy bypassing the Collect bureau data task) the Bankrupt and Credit Score parameters will be null.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Routing" id="_43183984-3eec-41fc-baf7-34fcc191145c" typeRef="tRouting"/>
+        <semantic:informationRequirement id="ee739559-dcee-442d-b00d-5a0cd840111b">
+            <semantic:requiredDecision href="#d_Post-bureauAffordability"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_8b2089f9-5ffe-422f-a6d5-a721dd360e13">
+            <semantic:requiredDecision href="#d_Post-bureauRiskCategory"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="ebed69f7-f1a5-4fc8-a659-1ebec3bf8f9f">
+            <semantic:requiredInput href="#i_BureauData"/>
+        </semantic:informationRequirement>
+        <semantic:knowledgeRequirement id="b2bee381-bb2c-429c-84e9-f9b0ed3aa0b6">
+            <semantic:requiredKnowledge href="#b_RoutingRules"/>
+        </semantic:knowledgeRequirement>
+        <semantic:invocation id="_94ca631a-4265-42f1-ab56-bb4ca797a92f" typeRef="tRouting">
+            <semantic:literalExpression id="literal__94ca631a-4265-42f1-ab56-bb4ca797a92f">
+                <semantic:text>Routing rules</semantic:text>
+            </semantic:literalExpression>
+            <semantic:binding>
+                <semantic:parameter id="_edd0d852-5be1-48bd-9016-8df97062fab3" name="Bankrupt"/>
+                <semantic:literalExpression id="_5c720446-2179-4084-bf1d-0469b96f2589">
+                    <semantic:text>Bureau data.Bankrupt</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_5da11983-3aea-4cf0-a519-a004c177fb75" name="Credit Score"/>
+                <semantic:literalExpression id="_64df4d54-afa8-4022-9be4-ab4dbb2f9e05">
+                    <semantic:text>Bureau data.CreditScore</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_fb6a03aa-52df-4760-a134-69cd474091e3" name="Post-Bureau Risk Category"/>
+                <semantic:literalExpression id="_66c356dc-34b4-4abf-99a2-3cf11f6a861c">
+                    <semantic:text>Post-bureau risk category</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+            <semantic:binding>
+                <semantic:parameter id="_925866c9-73e9-4cc7-9181-12c8980b7179" name="Post-Bureau Affordability"/>
+                <semantic:literalExpression id="_1b061ab0-c59e-4051-82fe-ca5c64c2074b">
+                    <semantic:text>Post-bureau affordability</semantic:text>
+                </semantic:literalExpression>
+            </semantic:binding>
+        </semantic:invocation>
+    </semantic:decision>
+    <semantic:decision id="d_Adjudication" name="Adjudication">
+        <semantic:variable name="Adjudication" id="_2e759926-5a19-42f4-b300-49400c9523c4" typeRef="tRouting"/>
+        <semantic:informationRequirement id="afde64ac-bdac-4ded-80b9-85a203c8e200">
+            <semantic:requiredInput href="#i_BureauData"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="d05f8b0a-91a7-4b7e-8400-8baf8d8a6fc9">
+            <semantic:requiredInput href="#i_SupportingDocuments"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="a3d7c6b7-f081-4418-9eb6-537b699e3d8a">
+            <semantic:requiredInput href="#i_ApplicantData"/>
+        </semantic:informationRequirement>
+        <semantic:informationRequirement id="_188013c7-ad88-4625-a60b-de17eab3c552">
+            <semantic:requiredDecision href="#d_Routing"/>
+        </semantic:informationRequirement>
+        <semantic:authorityRequirement id="_6347355a-5aec-47ef-a17d-ad5282ae86e0">
+            <semantic:requiredAuthority href="#_a3e9ef24-5b34-4e56-8a24-e8c02afb4587"/>
+        </semantic:authorityRequirement>
+        <semantic:literalExpression id="_1847c874-65eb-4517-be39-2f4740982bcd" typeRef="tRouting">
+            <semantic:text>Routing</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:businessKnowledgeModel id="b_AffordabilityCalculation" name="Affordability calculation">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from &lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Affordability calculation" id="_7bd63421-f97c-455d-8672-6ffdda94c5ef" typeRef="boolean"/>
+        <semantic:encapsulatedLogic id="_23234523-f7a5-497f-b9d2-af8fed4addd9" kind="FEEL" typeRef="boolean">
+            <semantic:formalParameter name="Monthly Income" typeRef="number" id="_1ed11494-da5d-4e13-bf29-bccd7650de8a"/>
+            <semantic:formalParameter name="Monthly Repayments" typeRef="number" id="_feeaf1e2-cd84-47f5-8cf3-200ffd8927be"/>
+            <semantic:formalParameter name="Monthly Expenses" typeRef="number" id="_b2422def-836c-4f0f-be7a-194be7e1c9a4"/>
+            <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory" id="_ca4f6e9e-7b53-4eef-96e2-9a435cc5fecf"/>
+            <semantic:formalParameter name="Required Monthly Installment" typeRef="number" id="_aea7b36f-f4ac-4a2b-9bfa-299d92c4e892"/>
+            <semantic:context id="_0dc94d1d-ab48-487a-b683-250e236b5a81">
+                <semantic:contextEntry id="_f2107e45-1b54-4d97-85d1-0878ba0315c3">
+                    <semantic:variable name="Disposable Income" id="_c3eb6efe-6c0f-481c-bde5-c26f09b238fe" typeRef="number"/>
+                    <semantic:literalExpression id="_e9b12816-85f3-4c04-94c6-50099beb66f6">
+                        <semantic:text>Monthly Income - (Monthly Expenses + Monthly Repayments)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_6d441b3e-9d06-488c-bc5d-a4d0a1355dec">
+                    <semantic:variable name="Credit Contingency Factor" id="_0ebff531-e471-4598-8d5c-65c47cd73860" typeRef="number"/>
+                    <semantic:invocation id="_95d09fe9-3181-4cd6-8f5e-2199865a79fc">
+                        <semantic:literalExpression id="literal__95d09fe9-3181-4cd6-8f5e-2199865a79fc">
+                            <semantic:text>Credit contingency factor table</semantic:text>
+                        </semantic:literalExpression>
+                        <semantic:binding>
+                            <semantic:parameter id="_754fcd7c-cb7f-4d02-849e-31b24509ca2a" name="Risk Category"/>
+                            <semantic:literalExpression id="_c74d5c91-6f31-446c-bf2a-b8a3c8186675">
+                                <semantic:text>Risk Category</semantic:text>
+                            </semantic:literalExpression>
+                        </semantic:binding>
+                    </semantic:invocation>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_6106935f-1ec1-46b2-8993-91b9a63da0c8">
+                    <semantic:variable name="Affordability" id="_439ac3dc-ede1-4cde-ad98-172920849998" typeRef="boolean"/>
+                    <semantic:literalExpression id="_d4fca9df-d5a0-44f9-a565-6e40b1731b94">
+                        <semantic:text>if Disposable Income * Credit Contingency Factor &gt; Required Monthly Installment&#10;then true&#10;else false</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_d4b9952d-e13a-4a4f-9b3e-d0feb3d2688c">
+                    <semantic:literalExpression id="_c78b320e-6ff1-4cf4-a8d3-1abf721fc391">
+                        <semantic:text>Affordability</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+        <semantic:knowledgeRequirement id="f7c70c78-8f51-43f2-9ee5-db6217226f18">
+            <semantic:requiredKnowledge href="#b_CreditContingencyFactorTable"/>
+        </semantic:knowledgeRequirement>
+        <semantic:authorityRequirement id="_f16612b3-b75d-4f0c-afad-b9a6544b332a">
+            <semantic:requiredAuthority href="#_68c16bb7-d43a-4fe0-89f1-f2f4f6857306"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_CreditContingencyFactorTable" name="Credit contingency factor table">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table &lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Credit contingency factor table" id="_6163b95e-f535-4eca-9983-43aa7decb342" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number">
+            <semantic:formalParameter name="Risk Category" typeRef="string"/>
+            <semantic:decisionTable id="_309ca296-4abb-499b-af1d-b2cf2479a2d4" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table">
+                <semantic:input id="_e2560603-2306-4519-b2aa-685723b61f73">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","HIGH","LOW","MEDIUM","VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_87634300-fea0-45a4-95c2-34fb7065956c"/>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_d715dba3-4c74-46b8-8551-1a9536e51d4c">
+                    <semantic:inputEntry id="_cee5824e-fcb8-44f8-8fc2-c0369babed07">
+                        <semantic:text>"HIGH", "DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_de290e8e-43a7-4a25-9bea-ba1aa4f449fb">
+                        <semantic:text>0.6</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_23a8dbe3-b09e-4980-b685-2f570f4991ad">
+                    <semantic:inputEntry id="_b2696416-2668-4436-a4b9-c17aeb51d378">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_39f451b2-d698-4781-ad8c-4987464cefff">
+                        <semantic:text>0.7</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_d62ca76b-610f-4fda-aeb9-8d3f0ad57cfe">
+                    <semantic:inputEntry id="_6fb19b93-2902-497c-b255-b5d5de68e4a8">
+                        <semantic:text>"LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_61c7d5bc-f497-45f7-bd69-8659fee89fe1">
+                        <semantic:text>0.8</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_557bfec0-0cf5-4102-85b8-8ef6afb55742">
+            <semantic:requiredAuthority href="#_ddd246af-8bdb-4371-864d-f52542394919"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_EligibilityRules" name="Eligibility rules">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility Rules &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table &lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Eligibility rules" id="_ba45293f-329d-49b8-bcc5-edf91781e9f1" typeRef="string"/>
+        <semantic:encapsulatedLogic typeRef="string">
+            <semantic:formalParameter name="Pre-bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Pre-bureau Affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:decisionTable id="_51ff058f-87f5-4f62-8cf1-79d905f5f1b2" hitPolicy="PRIORITY" outputLabel="Eligibility rules">
+                <semantic:input id="_2d5c6763-3dc4-424d-ac63-9b265996f13f">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_0d8a4de2-50af-4412-93c5-4d9902fe73b1">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Pre-bureau Affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_3688f9c0-a9fc-4dbb-840a-ae5129025796">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_5511c08a-c263-4111-b96a-668ab41d2170">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"INELIGIBLE","ELIGIBLE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_bee6e88f-12c8-47db-a639-b00498e0e570">
+                    <semantic:inputEntry id="_071e8a3e-35f5-4072-8b7c-cb6aa98bc52e">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1be427de-3f5d-4cdb-a62b-3d6723ded1e9">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4a57f72d-e4d9-4132-ad13-6ae0903a89d3">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_73e35e3b-ae67-451d-90d9-b374f6ac24e3">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_c0244fba-a5db-423b-b505-476184b4c284">
+                    <semantic:inputEntry id="_f41fec91-1acf-4457-9978-9643afcf5d13">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_43a93e77-e109-42b2-b31f-43236b8593dc">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ea413a0c-dbd3-4b58-8829-f412e3df0944">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f2662c26-d901-4eff-956f-254ba3cd42e6">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_fee473d0-c607-4d4a-b5d0-76c2f23aa3e5">
+                    <semantic:inputEntry id="_dcb17290-b883-4fac-ad36-bf176fd2bae4">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_eb6ed963-2cb5-4c8c-ad1d-02caf50c696f">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e53f56e9-536e-45f7-803b-898fa4c0e041">
+                        <semantic:text>&lt;18</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_723884ba-536c-4c49-87cc-79294823b371">
+                        <semantic:text>"INELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_2a539d88-59d6-4626-829a-5834ea90c705">
+                    <semantic:inputEntry id="_198ab95d-c9c7-4234-9516-6940695dae69">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_c7cca2c2-8291-4bad-95f8-7dd5c25dc1aa">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_28d4a863-2b4e-4ade-b3b8-6dc34dd7e842">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_af146a1a-6372-4004-be5f-05c1230126f8">
+                        <semantic:text>"ELIGIBLE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_704bd691-3c03-463a-bb4f-1c2905e40025">
+            <semantic:requiredAuthority href="#_3c9f2e5c-ff2a-4243-9065-63801a0a8158"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_BureauCallTypeTable" name="Bureau call type table">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving &lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Bureau call type table" id="_360c95f3-67a3-482a-96e6-6a28917ce067" typeRef="tBureaucallType"/>
+        <semantic:encapsulatedLogic typeRef="tBureaucallType">
+            <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:decisionTable id="_f3410833-21a2-49dc-a44a-123c356dc1d5" hitPolicy="UNIQUE" outputLabel="Bureau call type table">
+                <semantic:input id="_5d81767d-bb72-4ac7-bae8-58e09162d4a3">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Pre-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_336a6d6d-e152-47b9-8298-87ab96f40bf1">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"FULL","MINI","NONE"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_0a43b384-03cc-4463-8d2c-be0d313e1428">
+                    <semantic:inputEntry id="_473640df-8afa-4fcb-afc9-62f445fb6ddb">
+                        <semantic:text>"HIGH","MEDIUM"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ea7c5947-4b4d-4647-b87d-e835bdc78ef8">
+                        <semantic:text>"FULL"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_e063a15f-6307-4e5a-9832-3859571ea2f0">
+                    <semantic:inputEntry id="_a93fb297-a0e9-45e3-91b7-a0c3117a42d2">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_1595c634-83e2-4f0b-8cae-00cd13bd0664">
+                        <semantic:text>"MINI"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_36d00cf6-0ecb-4ac7-a6da-16d8d85a7a3c">
+                    <semantic:inputEntry id="_81852b3c-2a9f-409d-872f-0592004170d7">
+                        <semantic:text>"VERY LOW","DECLINE"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e84153d2-0209-4f68-a552-6b998e6752f1">
+                        <semantic:text>"NONE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_abf5456e-f31a-4d74-a1d6-7843dc69d73b">
+            <semantic:requiredAuthority href="#_ddd246af-8bdb-4371-864d-f52542394919"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_Pre-bureauRiskCategoryTable" name="Pre-bureau risk category table">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-Bureau Risk Category Table &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic (Figure 82) defines a complete, unique-hit decision table &lt;/span&gt;deriving Pre-Bureau Risk Category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Pre-bureau risk category table" id="_65d84d08-5b02-491a-84df-13f3325d21da" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:decisionTable id="_1d0b26ae-f3c7-42ee-8ea9-96303deb8fe5" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table">
+                <semantic:input id="_3df623a2-48be-49c4-85d8-820f0691a9d5">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_7b875789-213e-4008-aed8-b63f01a53996">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_ffe31eb2-d783-44fe-b7b6-e954d6c8f008">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_f19bdf72-1fc2-47b1-91ed-e5c1490fdf6f">
+                    <semantic:inputEntry id="_9b904a5d-5ddf-41b8-9698-0caa24dd7fba">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1ff720d6-2b8e-4e81-9d66-7b32f84c1089">
+                        <semantic:text>&lt;100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ff651af0-247b-418d-af98-c45719775887">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_aa17292e-24d2-49b8-9f3a-e30724dab6fe">
+                    <semantic:inputEntry id="_cc0f1399-2fb4-4116-a2ae-bd3c83d62f96">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1e4ae052-5573-40d7-9552-2ded5c3c413b">
+                        <semantic:text>[100..120)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_622080b8-82aa-4d53-9ec0-d8527379e1f5">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_3f812524-30fc-451c-b8c7-39838de31c39">
+                    <semantic:inputEntry id="_1e9f5378-924e-4ea4-9037-7fe26716bec7">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7b5bbf9b-e1cd-4d61-92c0-b5e4795eb200">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_958e0915-06fe-4f9b-a23e-cf07c8f258c0">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_036e0ca1-0471-4436-8a73-d49471031ec8">
+                    <semantic:inputEntry id="_e803cc6e-9d2a-410a-b0f5-59923b76217e">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1c9baf0d-da99-41f1-a936-c038406a9756">
+                        <semantic:text>&gt;130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_4a4191a6-1e1f-4d38-bbe8-c89962b42515">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_6d83018f-161f-4c67-a278-a6e87c88314e">
+                    <semantic:inputEntry id="_a8a793a3-3230-478c-a84e-71792e780756">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_9e8ace75-e93c-426d-8f14-55d05d0f67d1">
+                        <semantic:text>&lt;80</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_61d52221-e3f7-47de-a97c-1cc45b206003">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_204daa21-4438-4446-af94-28c7b529dc9d">
+                    <semantic:inputEntry id="_d60e8f8d-747f-45ca-a756-23e033f0ffed">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_91c7feb8-15b4-4582-9359-68f1c76a514c">
+                        <semantic:text>[80..90)</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_994e2ff7-3725-440c-bb62-f6bc4b2b42a4">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_153e6b15-1da2-4059-a14a-1f8a13fc9782">
+                    <semantic:inputEntry id="_bfe55b09-13a3-49a1-94b6-4be6b919b8ca">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0316d4d2-82a4-442f-a92a-19e58d399c70">
+                        <semantic:text>[90..110]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_b869cfeb-d931-47b8-aff4-6d955fd0f25f">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_90924881-06d2-45b6-a33c-e000d6016b7e">
+                    <semantic:inputEntry id="_563d3683-cdff-43ee-8dc8-913e800b40d5">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_181e52bc-f2e1-43eb-acd0-e95e2c45315f">
+                        <semantic:text>&gt;110</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_dc13e964-7ca9-48a7-8ecb-5bfc35e0f3dd">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_2450c1e2-1b4d-43ad-a6b6-04ae78ba4f1a">
+            <semantic:requiredAuthority href="#_ddd246af-8bdb-4371-864d-f52542394919"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_Post-bureauRiskCategoryTable" name="Post-Bureau Risk Category table">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table &lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Post-Bureau Risk Category table" id="_c3e1e9eb-0866-47c1-91da-ec5ed955b773" typeRef="tRiskCategory"/>
+        <semantic:encapsulatedLogic typeRef="tRiskCategory">
+            <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
+            <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
+            <semantic:formalParameter name="Credit Score" typeRef="number"/>
+            <semantic:decisionTable id="_b3460b2b-08c1-4f91-9e45-1da218209622" hitPolicy="UNIQUE" outputLabel="Post-Bureau Risk Category table">
+                <semantic:input id="_0a6b5178-dfbe-4400-ae48-f9a93391630d">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Existing Customer</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_365b1f9d-b282-4377-a6f5-f48a59bd8b27">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Application Risk Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_8e66e93c-3952-4876-b6a5-abe89c153552">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit Score</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:output id="_06b85a3d-dfc8-4805-a07a-02870a369503">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_a4bd60c0-340e-45e9-b92a-f272d23c2ebc">
+                    <semantic:inputEntry id="_41bd7e32-95bc-4cba-a085-7cabb2bb377c">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d9d99685-61f1-4bc8-b9b7-0e63c916bf40">
+                        <semantic:text>&lt;120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1d30e1c1-ad1a-4371-8f76-a50531f96f7c">
+                        <semantic:text>&lt;590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_11077924-dff7-4e1b-8a6c-d08edc3a5d34">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_1e20e2f8-cddb-4974-bd88-2bb0bf788b9b">
+                    <semantic:inputEntry id="_1bf12316-38e0-4787-a9bc-2648877ffa16">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2e477c19-e71e-4362-8fed-b6d8819a0075">
+                        <semantic:text>&lt;120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ec2bed60-ea45-42c3-81ea-2056b2e12ad6">
+                        <semantic:text>[590..610]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_d0b7830f-03ef-4c78-ac12-19b0ebbf481f">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_df5c283d-e387-4d29-bcd2-5e4cd585dae5">
+                    <semantic:inputEntry id="_018f3fcc-ff3e-4e66-9395-6bac19286402">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6217b418-2210-4aaa-888b-84959583100f">
+                        <semantic:text>&lt;120</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ec66bc77-b5bc-4211-a791-15a87588793d">
+                        <semantic:text>&gt;610</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f63a3d8e-7e06-4362-a813-f520e6f16e33">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_0f7224c0-6600-4d63-a072-e49ca8134cf1">
+                    <semantic:inputEntry id="_3702fce9-d9aa-46ed-8499-840c00628ee2">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b4a848dc-b573-4919-8cf1-e2a761ef5bb1">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_3a917fed-376a-48df-bf79-b3e0c75928d2">
+                        <semantic:text>&lt;600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_1d9b890e-fb00-49d8-b217-c930ea1a0900">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_f3e26b2c-b059-4238-ab04-4e3cf0e7e994">
+                    <semantic:inputEntry id="_e4645d55-ec30-4c53-9bda-03173627a349">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d36c58ef-93ec-499c-83d4-4b4d3aac3dbb">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4875371d-4d11-4b4c-82f7-8e122a00cb98">
+                        <semantic:text>[600..625]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_c2a1f74d-af8c-4372-92e1-174abd39cce2">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_48fff738-5d9c-4da2-b04d-1369a474e05c">
+                    <semantic:inputEntry id="_c3379b7e-3281-4bb0-97de-997c47cffa85">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_76f0f2cb-1ea6-4efe-ae87-efe449facdde">
+                        <semantic:text>[120..130]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_21c79573-406f-4f1e-ac39-6660a1c6ed96">
+                        <semantic:text>&gt;625</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_368d513e-fe2c-4c5a-ab22-bdf29c248c39">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_b7cb792b-c335-4f92-afc0-dd7a7cedaf11">
+                    <semantic:inputEntry id="_c8be31c3-9486-4286-96ff-2258c0283f6b">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_fec1412e-41eb-4198-a0cd-be8db0c9b876">
+                        <semantic:text>&gt;130</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_f5f366d8-5900-4372-8f91-77f635d4253c">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_f7af19d5-a871-49c9-9bfb-5dd053a67a0b">
+                        <semantic:text>"VERY LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_e000bbdc-baa0-4894-b870-0739b0173360">
+                    <semantic:inputEntry id="_88b5985e-30c8-40e4-a215-c03978b17bfe">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b02ee768-fb6f-4421-8b40-433ad345f7a8">
+                        <semantic:text>&lt;=100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_257f09d8-6e29-492c-9354-93c8ed6bc114">
+                        <semantic:text>&lt;580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3eaa3793-2639-4168-9f03-41482bab7285">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_e994df79-b2d0-4f26-af1e-fc8e41559b98">
+                    <semantic:inputEntry id="_7d7f1709-5fbe-4e58-a3c3-a726bdafd1a8">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_ebcb1562-bd6e-46ee-9271-bea940ab3252">
+                        <semantic:text>&lt;=100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7f7167e9-2488-4fa3-bbb0-036e244d05c1">
+                        <semantic:text>[580..600]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_49263d33-cdd7-44eb-a0f4-46339d7370b1">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_c57909cc-a44c-4746-9102-dff70a9bda2c">
+                    <semantic:inputEntry id="_2ab4f30f-5725-46b1-bc70-fa29a4f6c287">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e3bdc517-a96e-4ff9-a0a4-8dd3225e7abb">
+                        <semantic:text>&lt;=100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_18d61114-c2f2-4257-ad91-add9dd5ada27">
+                        <semantic:text>&gt;600</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_fece6641-337c-46a5-97d9-69a9caab70ce">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ccb0064b-4d77-4215-9207-a46d3c564e6c">
+                    <semantic:inputEntry id="_4c29916b-2b6f-441f-9954-ebf6f878cf15">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e66fa745-40bb-4dce-a251-8349bbc3a2f7">
+                        <semantic:text>&gt;100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_3b287b72-7389-4dd3-a03b-47ceabde334e">
+                        <semantic:text>&lt;590</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_7b1493ae-ec3a-45be-845c-d9b34a126630">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_28ad78a2-e78e-4243-aa80-f5c3006de7cb">
+                    <semantic:inputEntry id="_80cc2a75-fa36-4bc4-9b9b-8870364a001c">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e0e7fd7d-0915-4071-a93b-54c6f94e868b">
+                        <semantic:text>&gt;100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2b9bb3cf-a551-4349-b9c8-e03717fd6987">
+                        <semantic:text>[590..615]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_94f6bfea-bf34-44d0-b5bd-1d158a9af87f">
+                        <semantic:text>"MEDIUM"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_62f99d7b-53ec-4597-80a9-81597a765e40">
+                    <semantic:inputEntry id="_d7bb94b7-dc4a-41a3-9865-7b06b18e60a8">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_5b5fc575-e035-49d1-b92e-100bd2a4aabe">
+                        <semantic:text>&gt;100</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_dee3215e-90f8-4a41-a7f2-ab644161292c">
+                        <semantic:text>&gt;615</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_803798cc-38a6-4e97-b225-393f6e9aa44d">
+                        <semantic:text>"LOW"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_0013ad77-7d84-4d0e-9f37-4e72f22dce5f">
+            <semantic:requiredAuthority href="#_ddd246af-8bdb-4371-864d-f52542394919"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_ApplicationRiskScoreModel" name="Application risk score model">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table &lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;&#10;&lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Application risk score model" id="_e31a40e2-1358-4cad-8b88-df010aea529a" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number">
+            <semantic:formalParameter name="Age" typeRef="number"/>
+            <semantic:formalParameter name="Marital Status" typeRef="string"/>
+            <semantic:formalParameter name="Employment Status" typeRef="string"/>
+            <semantic:decisionTable id="_892d3a5c-10b3-4aaf-9eca-49030e34a4fd" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM">
+                <semantic:input id="_95a6902e-9510-4be9-8288-9f634857e120">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Age</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_5ecaefa7-efa6-4b26-ac0d-f092dde8b5ff">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Marital Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"S","M"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_f82e4af5-5062-4ba8-919d-347962eda854">
+                    <semantic:inputExpression typeRef="string">
+                        <semantic:text>Employment Status</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"UNEMPLOYED","EMPLOYED","SELF-EMPLOYED","STUDENT"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_d59f441e-f35a-44aa-9667-c2cbcbd64164"/>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_19e064b3-ad9e-4c0a-9f2a-382655915099">
+                    <semantic:inputEntry id="_03120920-6bc3-488f-8961-24d6a15213b1">
+                        <semantic:text>[18..21]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_09c5ec58-9b71-4f9a-bb25-718387524704">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_77c2c72e-f1d3-41f3-b38d-5fb2bf4d4e8a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_6a80a22b-cef4-42bb-8bc1-7b2770dbd8ef">
+                        <semantic:text>32</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_25dff821-c104-4be0-bae3-034a53b4e756">
+                    <semantic:inputEntry id="_9f87f3a8-ae5d-4382-89f5-cbcfc392f878">
+                        <semantic:text>[22..25]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_bc4e0898-4f96-4233-854b-a3cbd0bbb310">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_fff03c6e-ee74-4ffa-ad67-1f347b042691">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_e7b94764-5144-48c2-8cd1-0c94cb909e58">
+                        <semantic:text>35</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_d1119f29-7cd8-4787-943e-4229c12456f6">
+                    <semantic:inputEntry id="_3f975901-997e-4aa3-b7e7-9adb6723b621">
+                        <semantic:text>[26..35]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_11e710da-1d7e-4832-9dbe-a4d5df79f2da">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b5ad9d5a-6f94-4fc2-a75e-3d685efe1d1a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_a680718e-5cbb-4729-888e-7c7884221f83">
+                        <semantic:text>40</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_32092f33-6893-49dc-b588-521ba8a52ca4">
+                    <semantic:inputEntry id="_bb923ddb-c41c-4f90-8b9a-ca7162920abe">
+                        <semantic:text>[36..49]</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_36ff4ea6-2f3f-49f3-a8fb-a3791ea47b98">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4385b220-261e-4c7b-935b-6cf552ed9358">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_27bd614d-c06c-4943-8759-2b82c4d51c0f">
+                        <semantic:text>43</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_4da8c18e-9c1a-4620-abf4-80eba9d03841">
+                    <semantic:inputEntry id="_cdfffd8c-b52e-445d-acd8-c9b098ecf5cd">
+                        <semantic:text>&gt;=50</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_723382b9-6af9-4844-b0ba-f9d3436dfa67">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7560c6b2-505d-493a-86f4-09a38e3438f2">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_ed5f2e6b-fc47-4684-b5bb-5f2d2c3ea340">
+                        <semantic:text>48</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_78dd3241-4608-4766-aff7-d0b90efa1354">
+                    <semantic:inputEntry id="_a4fedf86-231c-4900-9d60-d3935d7c8b1d">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_686fe8f7-ac3e-4e3c-beda-c57f770a21ab">
+                        <semantic:text>"S"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_cbc155f4-b61e-449c-9464-d1c6f01f7cdf">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_46bf2d84-274c-451f-840c-12f0fd5f2fce">
+                        <semantic:text>25</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_8b6515c4-03e0-4468-822f-8f83c6738dd0">
+                    <semantic:inputEntry id="_57cfe987-1839-4f04-bc76-772bff9317de">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_32c37cff-c12a-4cdf-be21-723c758ff526">
+                        <semantic:text>"M"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_8e5fb424-ec03-42c2-b133-2ec56fa4a46b">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_a1576994-63ba-47c1-8b08-59432f52c108">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_76202b76-077e-43d5-b887-9407c248cfea">
+                    <semantic:inputEntry id="_af634ab7-d1a0-4e4f-a165-60aefe9b24dd">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_45ad1df2-1c9f-47b3-9b55-82a470b187e5">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1fdb800d-9cb4-4de6-9300-fec7cf32abe2">
+                        <semantic:text>"UNEMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_3400c5e1-b1f2-44fa-b30a-33e2aa4f56f1">
+                        <semantic:text>15</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ec41c28f-c6eb-4f89-aaf3-686a9338bff2">
+                    <semantic:inputEntry id="_4ced73b2-9a3e-4364-a243-39abd6790da8">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_7da91587-b9da-493b-bcd4-d913648b1687">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_928d0bb7-2afe-4be6-8b71-d0ffda0745a7">
+                        <semantic:text>"STUDENT"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_8bf1a4d3-6992-4fc9-92d5-c54d9a8b9c6f">
+                        <semantic:text>18</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_a9007362-7cd3-422b-9215-004702e8fcf2">
+                    <semantic:inputEntry id="_32b11c63-07ce-4833-9a43-b50e890215c1">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_61fb423a-d31b-427e-a243-43d604f8cb54">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_831e74ea-e14c-4025-8bf0-12332bfa9fcd">
+                        <semantic:text>"EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_80a3572b-c2df-40ba-a548-bf19c1257701">
+                        <semantic:text>45</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_ebf0a44e-d7a9-4464-a575-2e1aa7a7b906">
+                    <semantic:inputEntry id="_07fc2fcb-ae1c-4dd2-b93e-1be3ed3ca910">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6ce84947-0d94-4808-bc78-73abe5e631d1">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d7e9a7bc-a324-4ff8-8742-6228d8d736bb">
+                        <semantic:text>"SELF-EMPLOYED"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_00386955-a778-480d-963d-dbd8ddb0477f">
+                        <semantic:text>36</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_b69ba173-4a18-4a6f-b153-350b07a0b397">
+            <semantic:requiredAuthority href="#_aa1bfb73-ae57-4e53-ac32-3d5f7906f21e"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_InstallmentCalculation" name="Installment calculation">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment &lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Installment calculation" id="_93a92448-775c-4788-bbfc-2c75ae39d1cd" typeRef="number"/>
+        <semantic:encapsulatedLogic id="_4791c199-1950-4102-b6fc-d8f437b3085f" kind="FEEL" typeRef="number">
+            <semantic:formalParameter name="Product Type" typeRef="string" id="_bdbbeca3-5188-4af7-8331-7654ccb3d258"/>
+            <semantic:formalParameter name="Rate" typeRef="number" id="_81f0a941-0ead-4982-84c0-f692f89169c9"/>
+            <semantic:formalParameter name="Term" typeRef="number" id="_1a0925af-590a-4b52-88fc-0591fb8fcf1e"/>
+            <semantic:formalParameter name="Amount" typeRef="number" id="_3e77d023-4146-4f22-ae84-5439596bca47"/>
+            <semantic:context id="_67bf2c59-f467-4d70-80ae-15e39750d0eb">
+                <semantic:contextEntry id="_02f1175b-2215-4fc8-a850-4a359b81f726">
+                    <semantic:variable name="Monthly Fee" id="_51c801da-f395-42c7-b1ed-0b1efc4e34f8" typeRef="number"/>
+                    <semantic:literalExpression id="_d1cb1bf5-0c43-4887-bc70-9244a51778fd">
+                        <semantic:text>if Product Type ="STANDARD LOAN"&#10;then 20.00&#10;else if Product Type ="SPECIAL LOAN"&#10;then 25.00&#10;else null</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_d807973d-4a59-4435-8d60-14ff75013c49">
+                    <semantic:variable name="Monthly Repayment" id="_32123593-617e-476b-9c69-44adf57b9b44" typeRef="number"/>
+                    <semantic:literalExpression id="_85733c6f-6af0-45e9-bb9d-3dbb34b4a70b">
+                        <semantic:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+                <semantic:contextEntry id="_64526d38-2907-4fc7-be92-e0ad3f73b674">
+                    <semantic:literalExpression id="_b7b49a04-3a56-465e-81f5-321d085aa572">
+                        <semantic:text>Monthly Repayment+Monthly Fee</semantic:text>
+                    </semantic:literalExpression>
+                </semantic:contextEntry>
+            </semantic:context>
+        </semantic:encapsulatedLogic>
+    </semantic:businessKnowledgeModel>
+    <semantic:businessKnowledgeModel id="b_RoutingRules" name="Routing rules">
+        <semantic:description>&lt;p align="LEFT"&gt;&lt;span style="font-family: arial,helvetica,sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The &lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules &lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table &lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
+        <semantic:variable name="Routing rules" id="_56e3cd3e-0b85-46f0-9638-882029662e12" typeRef="number"/>
+        <semantic:encapsulatedLogic typeRef="number">
+            <semantic:formalParameter name="Post-Bureau Risk Category" typeRef="tRiskCategory"/>
+            <semantic:formalParameter name="Post-Bureau Affordability" typeRef="boolean"/>
+            <semantic:formalParameter name="Bankrupt" typeRef="boolean"/>
+            <semantic:formalParameter name="Credit Score" typeRef="number"/>
+            <semantic:decisionTable id="_3e1a9422-1092-4e23-a917-29f69b5820ee" hitPolicy="PRIORITY" outputLabel="Routing rules">
+                <semantic:input id="_e096a3a3-05ab-43b8-9762-e9b7928e6f33">
+                    <semantic:inputExpression typeRef="tRiskCategory">
+                        <semantic:text>Post-Bureau Risk Category</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE", "HIGH", "MEDIUM", "LOW", "VERY LOW"</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:input id="_9419f562-c0f4-4f1c-a18d-f58d122efef2">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Post-Bureau Affordability</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_09dafcb7-fbef-4be7-b404-3261eb7dad02">
+                    <semantic:inputExpression typeRef="boolean">
+                        <semantic:text>Bankrupt</semantic:text>
+                    </semantic:inputExpression>
+                </semantic:input>
+                <semantic:input id="_9c0a79e9-c1d2-493d-a1f2-5f51d4ca65e4">
+                    <semantic:inputExpression typeRef="number">
+                        <semantic:text>Credit Score</semantic:text>
+                    </semantic:inputExpression>
+                    <semantic:inputValues triso:constraintsType="expression">
+                        <semantic:text>null, [0..999]</semantic:text>
+                    </semantic:inputValues>
+                </semantic:input>
+                <semantic:output id="_2652e07f-48b9-4769-94c3-c563a708c0b8">
+                    <semantic:outputValues triso:constraintsType="enumeration">
+                        <semantic:text>"DECLINE","REFER","ACCEPT"</semantic:text>
+                    </semantic:outputValues>
+                </semantic:output>
+                <semantic:annotation name="Description"/>
+                <semantic:rule id="_c32fa85a-39a4-40ab-a497-4d22cf7b277e">
+                    <semantic:inputEntry id="_56284ad7-5e82-489e-92d0-594888cf0372">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_e5c93e9a-5067-4ea3-834c-47e4ba0dc17e">
+                        <semantic:text>false</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_b5b69019-aa99-4128-bf59-77ab7fa8accf">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_afcc7e6c-a4f9-48c5-bf9c-c8f8d721c23d">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_57670489-2156-4731-b9b3-63d1d98d7ed8">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_636a8af6-1e4d-4cc7-a59d-f7cb8d429443">
+                    <semantic:inputEntry id="_17654ce1-64b4-4fd9-9dd5-42f181a32e70">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_0ec948dd-30c4-4f99-bd02-dae10ccb17ff">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_2493a040-ede6-4113-9c06-dcdbcf04d7c6">
+                        <semantic:text>true</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_3875e439-ea11-4b23-8083-5ab7a7a4db76">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_a0d699b3-225e-450d-a6cd-99c03bf50055">
+                        <semantic:text>"DECLINE"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_72e9cb14-3a79-4fb6-87bd-372946bc8c9c">
+                    <semantic:inputEntry id="_444a53d8-aa33-4a13-b867-f49113b4b96c">
+                        <semantic:text>"HIGH"</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_621d37a9-af6d-4f8d-a02f-e8c88b05519a">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_1561724c-acfd-49c7-9fa7-354121f84833">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_5e53512e-55be-42ef-a3d5-0d4f70021b66">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_0b705075-2afe-46d2-9882-41ddce8c74bf">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_93f06b82-f30b-4575-8632-21df10ccc3b6">
+                    <semantic:inputEntry id="_b8dafcad-fd6d-49c2-90f4-f23bf5155857">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_4627e22e-aefa-4841-8b2f-5d7a00220792">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d27ec9cb-e902-4564-9157-02fcea414ebc">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6be60a8a-ccf9-4be3-9a35-c3034b871db8">
+                        <semantic:text>&lt;580</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_52348d8e-c338-4fff-8368-4dee8762ee1e">
+                        <semantic:text>"REFER"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+                <semantic:rule id="_6999bb00-4eca-4dc0-ad42-d20359e64be4">
+                    <semantic:inputEntry id="_6ab81ed2-51fe-4f43-b834-97ced8a3dd18">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_d50e9f55-f1f0-428a-8264-8ab18e9d3f37">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_6ad0a8e9-414d-4ba3-b9ff-e5d8c1d01cc7">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:inputEntry id="_136479ca-840c-4fb7-aa85-0a6f7be75e7e">
+                        <semantic:text>-</semantic:text>
+                    </semantic:inputEntry>
+                    <semantic:outputEntry id="_c5a05378-b6fb-4c61-a3c4-68156d943ae9">
+                        <semantic:text>"ACCEPT"</semantic:text>
+                    </semantic:outputEntry>
+                    <semantic:annotationEntry>
+                        <semantic:text></semantic:text>
+                    </semantic:annotationEntry>
+                </semantic:rule>
+            </semantic:decisionTable>
+        </semantic:encapsulatedLogic>
+        <semantic:authorityRequirement id="_377f7a2d-79c7-4344-b449-61184f5fbec3">
+            <semantic:requiredAuthority href="#_3c9f2e5c-ff2a-4243-9065-63801a0a8158"/>
+        </semantic:authorityRequirement>
+    </semantic:businessKnowledgeModel>
+    <semantic:inputData id="i_ApplicantData" name="Applicant data">
+        <semantic:variable name="Applicant data" id="_a72a88c1-db0d-4f0f-8617-1cfdc584bdd2" typeRef="tApplicantData"/>
+    </semantic:inputData>
+    <semantic:inputData id="i_BureauData" name="Bureau data">
+        <semantic:variable name="Bureau data" id="_942043f8-485a-49dd-9e5f-6aefebc43f8b" typeRef="tBureauData"/>
+    </semantic:inputData>
+    <semantic:inputData id="i_RequestedProduct" name="Requested product">
+        <semantic:variable name="Requested product" id="_a605bdc7-92cb-4500-9d63-b264626fb61f" typeRef="tRequestedProduct"/>
+    </semantic:inputData>
+    <semantic:inputData id="i_SupportingDocuments" name="Supporting documents">
+        <semantic:variable name="Supporting documents" id="_2ac7c4aa-c31a-40a7-a815-30112d7a8e5a" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:knowledgeSource id="_a3e9ef24-5b34-4e56-8a24-e8c02afb4587" name="Credit officer"/>
+    <semantic:knowledgeSource id="_aa1bfb73-ae57-4e53-ac32-3d5f7906f21e" name="Analytics"/>
+    <semantic:knowledgeSource id="_ddd246af-8bdb-4371-864d-f52542394919" name="Risk manager"/>
+    <semantic:knowledgeSource id="_3c9f2e5c-ff2a-4243-9065-63801a0a8158" name="Product specification"/>
+    <semantic:knowledgeSource id="_68c16bb7-d43a-4fe0-89f1-f2f4f6857306" name="Affordability spreadsheet"/>
+    <semantic:textAnnotation id="_5ee7bdae-1f5f-4888-a689-b426b5273a25">
+        <semantic:text>This example was recreated according to Chapter 11 of DMN 1.1 specification.&#10;&#10;Types tRiskCategory, tStrategy, tBureauCallType, tEligibility were created with constraints and used where applicable&#10;&#10;In Trisotech DMN Modeler, the output label is always the same than the decision table name.&#10;&#10;Description found on each element were all taken from DMN 1.1 Specification.</semantic:text>
+    </semantic:textAnnotation>
+    <semantic:textAnnotation id="_dee72acb-ac67-47d3-a57e-6ad186d795da">
+        <semantic:text>The PMT function was locally reproduced so the example is self contained</semantic:text>
+    </semantic:textAnnotation>
+    <semantic:association id="_bf057dfe-f5d4-4fde-9dee-b4bf5fde4c9d">
+        <semantic:sourceRef href="#_dee72acb-ac67-47d3-a57e-6ad186d795da"/>
+        <semantic:targetRef href="#b_InstallmentCalculation"/>
+    </semantic:association>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_D1" name="Page 1" documentation="&lt;p align=&quot;LEFT&quot;&gt;&lt;span style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;This diagram shows&amp;nbsp;the DRD found at Figure 70 of DMN 1.1 Specification. It includes all the decisions used by the example.&lt;/span&gt;&lt;/p&gt;&#10;&lt;p align=&quot;LEFT&quot;&gt;&lt;span style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;There are four sources of input data for the decision-making (Requested product, Applicant data, Bureau data and Supporting documents), and four decisions whose results are used in the business process (Strategy, Bureau call type, Routing and Adjudication). Between the two are intermediate decisions: evaluations of risk, affordability and eligibility. Notable features of this DRD include:&lt;/span&gt;&lt;/p&gt;&#10;&lt;ul&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span lang=&quot;JA&quot; style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;It covers both automated and human decision-making.&lt;/span&gt;&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;Some decisions (e.g., Pre-bureau risk category) and input data (e.g., Applicant data) are required by multiple &lt;/span&gt;&lt;/span&gt;decisions, i.e., the information requirements network is not a tree.&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span lang=&quot;JA&quot; style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;Business knowledge models (see Affordability calculation) may be invoked by multiple decisions.&lt;/span&gt;&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;Business knowledge models (see Credit contingency factor) may be invoked by other business knowledge &lt;/span&gt;&lt;/span&gt;models.&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span lang=&quot;JA&quot; style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;Some decisions do not have associated business knowledge models.&lt;/span&gt;&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;li&gt;&#10;&lt;div align=&quot;LEFT&quot;&gt;&lt;span lang=&quot;JA&quot; style=&quot;font-family: arial,helvetica,sans-serif; font-size: 10pt;&quot;&gt;&lt;span lang=&quot;JA&quot;&gt;Knowledge sources may provide authority for multiple decisions and/or business knowledge models.&lt;/span&gt;&lt;/span&gt;&lt;/div&gt;&#10;&lt;/li&gt;&#10;&lt;/ul&gt;">
+            <dmndi:Size height="1266" width="1823.215688952571"/>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s1" dmnElementRef="d_BureauCallType">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="252.00000381469727" y="331" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s2" dmnElementRef="d_Strategy">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="359.00000381469727" y="150" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s3" dmnElementRef="d_Eligibility">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="466.00000381469727" y="331" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s4" dmnElementRef="d_Pre-bureauRiskCategory">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="315.00000381469727" y="757" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s5" dmnElementRef="d_Post-bureauRiskCategory">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1389.0000038146973" y="693" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s6" dmnElementRef="d_ApplicationRiskScore">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="315.00000381469727" y="938" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s7" dmnElementRef="d_Pre-bureauAffordability">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="676.0000038146973" y="512" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s8" dmnElementRef="d_Post-bureauAffordability">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1161.0000038146973" y="512" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s9" dmnElementRef="d_RequiredMonthlyInstallment">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="907.0000038146973" y="970" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s10" dmnElementRef="d_Routing">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1265.0000038146973" y="331" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s11" dmnElementRef="d_Adjudication">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1338.0000038146973" y="97.7069511413575" width="154" height="60.999999999999986"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s12" dmnElementRef="b_AffordabilityCalculation">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="907.0000038146974" y="512" width="153.9999999999999" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s13" dmnElementRef="b_CreditContingencyFactorTable">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="802.0000038146973" y="406" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s14" dmnElementRef="b_EligibilityRules">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="698.0000038146973" y="331" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s15" dmnElementRef="b_BureauCallTypeTable">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="115.00000381469727" y="512" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s16" dmnElementRef="b_Pre-bureauRiskCategoryTable">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="189.00000381469727" y="851" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s17" dmnElementRef="b_Post-bureauRiskCategoryTable">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1451.7451030272148" y="789.3529408464794" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s18" dmnElementRef="b_ApplicationRiskScoreModel">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="228.00000381469727" y="1044.5" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s19" dmnElementRef="b_InstallmentCalculation">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="988.0000038146973" y="1106" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s20" dmnElementRef="b_RoutingRules">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1034.0000038146973" y="331" width="154" height="61"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s21" dmnElementRef="i_ApplicantData">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="618.9215725154796" y="1055" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s22" dmnElementRef="i_BureauData">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1620.215688952571" y="693.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s23" dmnElementRef="i_RequestedProduct">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="802.5000038146973" y="1106.5" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_s24" dmnElementRef="i_SupportingDocuments">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1496.0000038146973" y="207.70695114135748" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_446f23a0-f711-4deb-92c9-64d457b792c1" dmnElementRef="_a3e9ef24-5b34-4e56-8a24-e8c02afb4587">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1133" y="93.29304885864265" width="100.00000762939453" height="69.82780456542967"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_f664a049-7d71-4d30-9942-f49065ead816" dmnElementRef="_aa1bfb73-ae57-4e53-ac32-3d5f7906f21e">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="82" y="979.0860977172852" width="100.00000762939453" height="69.82780456542969"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_87024878-2374-41e6-8774-90a7f68cc6f5" dmnElementRef="_ddd246af-8bdb-4371-864d-f52542394919">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="60" y="657.5860977172852" width="100.00000762939453" height="69.82780456542969"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_52d70217-1e72-477c-9e2b-ba3815832001" dmnElementRef="_3c9f2e5c-ff2a-4243-9065-63801a0a8158">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="884.8899841308594" y="198.58609771728516" width="100.00000762939453" height="69.82780456542969"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_050d3ee0-685e-47f4-8c6c-862c1c70178e" dmnElementRef="_68c16bb7-d43a-4fe0-89f1-f2f4f6857306">
+                <dmndi:DMNStyle>
+                    <dmndi:FillColor red="255" green="255" blue="255"/>
+                </dmndi:DMNStyle>
+                <dc:Bounds x="1034.0000038146973" y="412.58609771728516" width="100.00000762939453" height="69.82780456542969"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_04698dd8-e0a8-4e13-a5f0-c308d05b05d9" dmnElementRef="_5ee7bdae-1f5f-4888-a689-b426b5273a25">
+                <dc:Bounds x="50" y="61.20695114135748" width="277" height="177"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_3ff878e1-2651-4726-aa95-2730d55e1788" dmnElementRef="_dee72acb-ac67-47d3-a57e-6ad186d795da">
+                <dc:Bounds x="1222" y="1033" width="182" height="51"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e1" dmnElementRef="f648a91d-f751-47b8-a463-72d324575272">
+                <di:waypoint x="192.00000381469727" y="512"/>
+                <di:waypoint x="329.00000381469727" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e2" dmnElementRef="_25fc0e89-3b15-4227-9173-0cfed5d10f0c">
+                <di:waypoint x="329.00000381469727" y="331"/>
+                <di:waypoint x="436.00000381469727" y="211"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e3" dmnElementRef="_68c00aa8-cd88-4898-a61e-c9dacbcdbd70">
+                <di:waypoint x="543.0000038146973" y="331"/>
+                <di:waypoint x="436.00000381469727" y="211"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e5" dmnElementRef="_44b4bed2-257c-4272-ac89-9adc628ed9c2">
+                <di:waypoint x="753.0000038146973" y="512"/>
+                <di:waypoint x="583.261441723194" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e6" dmnElementRef="_574df70d-4de6-401f-b467-1ae637317467">
+                <di:waypoint x="266.00000381469727" y="851"/>
+                <di:waypoint x="351.7385659062005" y="818"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e7" dmnElementRef="_8f0f908c-60fa-4e69-8f4d-27bb44f11356">
+                <di:waypoint x="392.00000381469727" y="938"/>
+                <di:waypoint x="392.00000381469727" y="818"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e8" dmnElementRef="dafcb6b1-111b-416c-a031-d7c9d9a79d8e">
+                <di:waypoint x="1528.7451030272148" y="789.3529408464794"/>
+                <di:waypoint x="1466.0000038146973" y="754"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e9" dmnElementRef="_690238e8-9d1a-4060-b9f1-7754124f0bbf">
+                <di:waypoint x="392.00000381469727" y="938"/>
+                <di:waypoint x="1389.0000038146973" y="723.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e10" dmnElementRef="_96de0bbf-d9a3-4b95-80c2-0ac6b4dc6a8a">
+                <di:waypoint x="1620.4115612593948" y="723.5"/>
+                <di:waypoint x="1543.0000038146973" y="723.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e11" dmnElementRef="_9d683062-3860-4508-8827-3d7b71b315d0">
+                <di:waypoint x="305.00000381469727" y="1044.5"/>
+                <di:waypoint x="392.00000381469727" y="999"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e12" dmnElementRef="b8db8e29-b181-41c4-80d5-7ceaa8b5565d">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="392.00000381469727" y="999"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e13" dmnElementRef="bfa6e573-f32a-49e7-8d2b-83552484035e">
+                <di:waypoint x="907.0000038146974" y="541.9830508474577"/>
+                <di:waypoint x="830.0000038146973" y="542.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e14" dmnElementRef="_6b2fcd2c-3211-48c1-9937-705b38922963">
+                <di:waypoint x="984.0000038146973" y="970"/>
+                <di:waypoint x="773.1307227689456" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e15" dmnElementRef="_43edd81a-aed9-48ae-a1a7-644f528b8d3f">
+                <di:waypoint x="392.00000381469727" y="757"/>
+                <di:waypoint x="722.8039253833247" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e16" dmnElementRef="_6ab262b3-f743-4f8d-a2cb-88948f96f92c">
+                <di:waypoint x="1061.0000038146973" y="541.9830508474577"/>
+                <di:waypoint x="1161.0000038146973" y="542.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e17" dmnElementRef="_0b4e7ee2-d280-4afe-8f70-1706662c9015">
+                <di:waypoint x="984.0000038146973" y="970"/>
+                <di:waypoint x="1238.0000038146973" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e18" dmnElementRef="_257cab3f-11cc-4d9c-b904-2b1cf696c9c3">
+                <di:waypoint x="1466.0000038146973" y="693"/>
+                <di:waypoint x="1238.0000038146973" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e19" dmnElementRef="e144b843-7b9a-4525-b648-4f54aa3633c2">
+                <di:waypoint x="1065.0000038146973" y="1106"/>
+                <di:waypoint x="984.0000038146973" y="1031"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e20" dmnElementRef="e97efbf5-a718-44ac-a6fd-e8953a7a41fe">
+                <di:waypoint x="878.5000038146973" y="1106.5"/>
+                <di:waypoint x="984.0000038146973" y="1031"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e21" dmnElementRef="b2bee381-bb2c-429c-84e9-f9b0ed3aa0b6">
+                <di:waypoint x="1188.0000038146973" y="360.9830508474576"/>
+                <di:waypoint x="1265.0000038146973" y="361.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e22" dmnElementRef="ee739559-dcee-442d-b00d-5a0cd840111b">
+                <di:waypoint x="1238.0000038146973" y="512"/>
+                <di:waypoint x="1311.8039253833247" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e23" dmnElementRef="afde64ac-bdac-4ded-80b9-85a203c8e200">
+                <di:waypoint x="1696.215688952571" y="693.5"/>
+                <di:waypoint x="1415.0000038146973" y="158.70695114135748"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e24" dmnElementRef="d05f8b0a-91a7-4b7e-8400-8baf8d8a6fc9">
+                <di:waypoint x="1572.0000038146973" y="207.70695114135748"/>
+                <di:waypoint x="1455.261441723194" y="158.70695114135748"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e25" dmnElementRef="f7c70c78-8f51-43f2-9ee5-db6217226f18">
+                <di:waypoint x="898.2500038146973" y="467"/>
+                <di:waypoint x="942.4605301304867" y="512"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e26" dmnElementRef="_27f91e41-4f06-46b4-974d-6ae45e8fcc68">
+                <di:waypoint x="392.00000381469727" y="757"/>
+                <di:waypoint x="329.00000381469727" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e27" dmnElementRef="e84f4293-9564-4806-ac95-c44db1e12129">
+                <di:waypoint x="392.00000381469727" y="757"/>
+                <di:waypoint x="502.7385659062005" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e28" dmnElementRef="_11982879-3f7f-4fd2-97c9-2f632bb7ee48">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="543.0000038146973" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e29" dmnElementRef="_90bf8067-8ba9-4a89-95c4-f461736be09b">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="432.261441723194" y="818"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e30" dmnElementRef="_51c0f9a0-362e-43e0-add9-40c57432ab36">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="1415.6732064290763" y="754"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e31" dmnElementRef="_77752640-b080-4145-8a46-c2df81174027">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="753.0000038146973" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e32" dmnElementRef="_7385eb68-33e7-456b-8ba4-05a2ed13acdb">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="1238.0000038146973" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e33" dmnElementRef="_8b2089f9-5ffe-422f-a6d5-a721dd360e13">
+                <di:waypoint x="1466.0000038146973" y="693"/>
+                <di:waypoint x="1342.0000038146973" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e34" dmnElementRef="ebed69f7-f1a5-4fc8-a659-1ebec3bf8f9f">
+                <di:waypoint x="1685.4095025581223" y="693.5"/>
+                <di:waypoint x="1372.1960822460699" y="392"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_4e0f0b70-d31c-471c-bd52-5ca709ed362b_e35" dmnElementRef="a3d7c6b7-f081-4418-9eb6-537b699e3d8a">
+                <di:waypoint x="694.9215725154796" y="1055"/>
+                <di:waypoint x="1384.8039253833247" y="158.70695114135748"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_d1e831e6-d6b0-43b0-9235-ef3636206ea2" dmnElementRef="_6347355a-5aec-47ef-a17d-ad5282ae86e0">
+                <di:waypoint x="1233" y="127.79304885864263"/>
+                <di:waypoint x="1338.0000038146973" y="128.20695114135748"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_ad146077-34f6-4875-bf10-707c50531b6d" dmnElementRef="_b69ba173-4a18-4a6f-b153-350b07a0b397">
+                <di:waypoint x="132" y="1039.0860977172852"/>
+                <di:waypoint x="228.00000381469727" y="1084.822033898305"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_a4b7cde0-42d7-4f50-a35f-faddf48889a4" dmnElementRef="_abf5456e-f31a-4d74-a1d6-7843dc69d73b">
+                <di:waypoint x="110.00000381469727" y="657.5860977172852"/>
+                <di:waypoint x="180.855266972592" y="573"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_74c6f321-5ddb-4f57-bef3-b1675406598d" dmnElementRef="_2450c1e2-1b4d-43ad-a6b6-04ae78ba4f1a">
+                <di:waypoint x="110" y="717.5860977172852"/>
+                <di:waypoint x="224.46053013048675" y="851"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_9e784a04-f445-423b-b561-983cb2457158" dmnElementRef="_557bfec0-0cf5-4102-85b8-8ef6afb55742">
+                <di:waypoint x="160" y="681.9860977172851"/>
+                <di:waypoint x="802.0000038146973" y="435.98305084745766"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_578b53de-a102-4946-8704-4b04d5cd0133" dmnElementRef="_849a5e3b-a57b-4808-b37e-19266d92f99c">
+                <di:waypoint x="698.0000038146973" y="360.9830508474576"/>
+                <di:waypoint x="620.0000038146973" y="361.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0595ac2c-f24b-4276-92c6-ad97d1dc4b51" dmnElementRef="_704bd691-3c03-463a-bb4f-1c2905e40025">
+                <di:waypoint x="897.3899841308594" y="265.58609771728516"/>
+                <di:waypoint x="784.1184248673288" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e2879bfd-8196-41d7-a4c1-0d8e9bdf93f6" dmnElementRef="_377f7a2d-79c7-4344-b449-61184f5fbec3">
+                <di:waypoint x="947.3899841308594" y="251.58609771728516"/>
+                <di:waypoint x="1120.118424867329" y="331"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_55ea623a-7ef7-49f1-adf9-e5edfe187d76" dmnElementRef="_f16612b3-b75d-4f0c-afad-b9a6544b332a">
+                <di:waypoint x="1059.0000038146973" y="482.58609771728516"/>
+                <di:waypoint x="982.9868459199604" y="512"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_293749d9-e5d0-44bd-b2b8-ec2dc6525482" dmnElementRef="_0013ad77-7d84-4d0e-9f37-4e72f22dce5f">
+                <di:waypoint x="160" y="692.0860977172852"/>
+                <di:waypoint x="1451.7451030272148" y="819.3359916939371"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_e7bf7d8f-ae00-498a-8ecb-02aac3a5ac87" dmnElementRef="_188013c7-ad88-4625-a60b-de17eab3c552">
+                <di:waypoint x="1342.0000038146973" y="331"/>
+                <di:waypoint x="1394.869284860449" y="158.70695114135748"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_b3217c4c-f649-46c8-b11a-bc455a69facc" dmnElementRef="_bf057dfe-f5d4-4fde-9dee-b4bf5fde4c9d">
+                <di:waypoint x="1225.64" y="1060.54"/>
+                <di:waypoint x="1142.0000038146973" y="1136.5"/>
+                <dmndi:DMNLabel sharedStyle="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_3068644b-d2c7-4b81-ab9d-64f011f81f47_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/drl/rules.drl
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/drl/rules.drl
@@ -1,0 +1,725 @@
+package org.drools.benchmarks.bre;
+
+import org.drools.benchmarks.common.model.Account;
+import org.drools.benchmarks.common.model.Address;
+import org.drools.benchmarks.common.model.Customer;
+
+rule "accountBalance1"
+when 
+    $account : Account(balance == 1)
+then
+    modify ($account) { setBalance(-1) };
+end
+
+rule "postalCode1"
+when 
+    $address : Address(postCode != "1")
+then
+    modify ($address) { setPostCode("1") };
+end
+
+rule "accountOwner1"
+when 
+    $account : Account(balance == 1)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-1) };
+end
+
+rule "BrnoPrahaOstrava1"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "1"))
+then
+    modify ($address) { setCity("1") };
+end
+
+rule "exists1"
+when 
+    $customer: Customer(firstName == "Jake1")
+then
+    modify ($customer) {setFirstName("Jackie1")} 
+end
+
+rule "accountBalance2"
+when 
+    $account : Account(balance == 2)
+then
+    modify ($account) { setBalance(-2) };
+end
+
+rule "postalCode2"
+when 
+    $address : Address(postCode != "2")
+then
+    modify ($address) { setPostCode("2") };
+end
+
+rule "accountOwner2"
+when 
+    $account : Account(balance == 2)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-2) };
+end
+
+rule "BrnoPrahaOstrava2"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "2"))
+then
+    modify ($address) { setCity("2") };
+end
+
+rule "exists2"
+when 
+    $customer: Customer(firstName == "Jake2")
+then
+    modify ($customer) {setFirstName("Jackie2")} 
+end
+
+rule "accountBalance3"
+when 
+    $account : Account(balance == 3)
+then
+    modify ($account) { setBalance(-3) };
+end
+
+rule "postalCode3"
+when 
+    $address : Address(postCode != "3")
+then
+    modify ($address) { setPostCode("3") };
+end
+
+rule "accountOwner3"
+when 
+    $account : Account(balance == 3)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-3) };
+end
+
+rule "BrnoPrahaOstrava3"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "3"))
+then
+    modify ($address) { setCity("3") };
+end
+
+rule "exists3"
+when 
+    $customer: Customer(firstName == "Jake3")
+then
+    modify ($customer) {setFirstName("Jackie3")} 
+end
+
+rule "accountBalance4"
+when 
+    $account : Account(balance == 4)
+then
+    modify ($account) { setBalance(-4) };
+end
+
+rule "postalCode4"
+when 
+    $address : Address(postCode != "4")
+then
+    modify ($address) { setPostCode("4") };
+end
+
+rule "accountOwner4"
+when 
+    $account : Account(balance == 4)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-4) };
+end
+
+rule "BrnoPrahaOstrava4"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "4"))
+then
+    modify ($address) { setCity("4") };
+end
+
+rule "exists4"
+when 
+    $customer: Customer(firstName == "Jake4")
+then
+    modify ($customer) {setFirstName("Jackie4")} 
+end
+
+rule "accountBalance5"
+when 
+    $account : Account(balance == 5)
+then
+    modify ($account) { setBalance(-5) };
+end
+
+rule "postalCode5"
+when 
+    $address : Address(postCode != "5")
+then
+    modify ($address) { setPostCode("5") };
+end
+
+rule "accountOwner5"
+when 
+    $account : Account(balance == 5)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-5) };
+end
+
+rule "BrnoPrahaOstrava5"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "5"))
+then
+    modify ($address) { setCity("5") };
+end
+
+rule "exists5"
+when 
+    $customer: Customer(firstName == "Jake5")
+then
+    modify ($customer) {setFirstName("Jackie5")} 
+end
+
+rule "accountBalance6"
+when 
+    $account : Account(balance == 6)
+then
+    modify ($account) { setBalance(-6) };
+end
+
+rule "postalCode6"
+when 
+    $address : Address(postCode != "6")
+then
+    modify ($address) { setPostCode("6") };
+end
+
+rule "accountOwner6"
+when 
+    $account : Account(balance == 6)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-6) };
+end
+
+rule "BrnoPrahaOstrava6"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "6"))
+then
+    modify ($address) { setCity("6") };
+end
+
+rule "exists6"
+when 
+    $customer: Customer(firstName == "Jake6")
+then
+    modify ($customer) {setFirstName("Jackie6")} 
+end
+
+rule "accountBalance7"
+when 
+    $account : Account(balance == 7)
+then
+    modify ($account) { setBalance(-7) };
+end
+
+rule "postalCode7"
+when 
+    $address : Address(postCode != "7")
+then
+    modify ($address) { setPostCode("7") };
+end
+
+rule "accountOwner7"
+when 
+    $account : Account(balance == 7)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-7) };
+end
+
+rule "BrnoPrahaOstrava7"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "7"))
+then
+    modify ($address) { setCity("7") };
+end
+
+rule "exists7"
+when 
+    $customer: Customer(firstName == "Jake7")
+then
+    modify ($customer) {setFirstName("Jackie7")} 
+end
+
+rule "accountBalance8"
+when 
+    $account : Account(balance == 8)
+then
+    modify ($account) { setBalance(-8) };
+end
+
+rule "postalCode8"
+when 
+    $address : Address(postCode != "8")
+then
+    modify ($address) { setPostCode("8") };
+end
+
+rule "accountOwner8"
+when 
+    $account : Account(balance == 8)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-8) };
+end
+
+rule "BrnoPrahaOstrava8"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "8"))
+then
+    modify ($address) { setCity("8") };
+end
+
+rule "exists8"
+when 
+    $customer: Customer(firstName == "Jake8")
+then
+    modify ($customer) {setFirstName("Jackie8")} 
+end
+
+rule "accountBalance9"
+when 
+    $account : Account(balance == 9)
+then
+    modify ($account) { setBalance(-9) };
+end
+
+rule "postalCode9"
+when 
+    $address : Address(postCode != "9")
+then
+    modify ($address) { setPostCode("9") };
+end
+
+rule "accountOwner9"
+when 
+    $account : Account(balance == 9)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-9) };
+end
+
+rule "BrnoPrahaOstrava9"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "9"))
+then
+    modify ($address) { setCity("9") };
+end
+
+rule "exists9"
+when 
+    $customer: Customer(firstName == "Jake9")
+then
+    modify ($customer) {setFirstName("Jackie9")} 
+end
+
+rule "accountBalance10"
+when 
+    $account : Account(balance == 10)
+then
+    modify ($account) { setBalance(-10) };
+end
+
+rule "postalCode10"
+when 
+    $address : Address(postCode != "10")
+then
+    modify ($address) { setPostCode("10") };
+end
+
+rule "accountOwner10"
+when 
+    $account : Account(balance == 10)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-10) };
+end
+
+rule "BrnoPrahaOstrava10"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "10"))
+then
+    modify ($address) { setCity("10") };
+end
+
+rule "exists10"
+when 
+    $customer: Customer(firstName == "Jake10")
+then
+    modify ($customer) {setFirstName("Jackie10")} 
+end
+
+rule "accountBalance11"
+when 
+    $account : Account(balance == 11)
+then
+    modify ($account) { setBalance(-11) };
+end
+
+rule "postalCode11"
+when 
+    $address : Address(postCode != "11")
+then
+    modify ($address) { setPostCode("11") };
+end
+
+rule "accountOwner11"
+when 
+    $account : Account(balance == 11)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-11) };
+end
+
+rule "BrnoPrahaOstrava11"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "11"))
+then
+    modify ($address) { setCity("11") };
+end
+
+rule "exists11"
+when 
+    $customer: Customer(firstName == "Jake11")
+then
+    modify ($customer) {setFirstName("Jackie11")} 
+end
+
+rule "accountBalance12"
+when 
+    $account : Account(balance == 12)
+then
+    modify ($account) { setBalance(-12) };
+end
+
+rule "postalCode12"
+when 
+    $address : Address(postCode != "12")
+then
+    modify ($address) { setPostCode("12") };
+end
+
+rule "accountOwner12"
+when 
+    $account : Account(balance == 12)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-12) };
+end
+
+rule "BrnoPrahaOstrava12"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "12"))
+then
+    modify ($address) { setCity("12") };
+end
+
+rule "exists12"
+when 
+    $customer: Customer(firstName == "Jake12")
+then
+    modify ($customer) {setFirstName("Jackie12")} 
+end
+
+rule "accountBalance13"
+when 
+    $account : Account(balance == 13)
+then
+    modify ($account) { setBalance(-13) };
+end
+
+rule "postalCode13"
+when 
+    $address : Address(postCode != "13")
+then
+    modify ($address) { setPostCode("13") };
+end
+
+rule "accountOwner13"
+when 
+    $account : Account(balance == 13)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-13) };
+end
+
+rule "BrnoPrahaOstrava13"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "13"))
+then
+    modify ($address) { setCity("13") };
+end
+
+rule "exists13"
+when 
+    $customer: Customer(firstName == "Jake13")
+then
+    modify ($customer) {setFirstName("Jackie13")} 
+end
+
+rule "accountBalance14"
+when 
+    $account : Account(balance == 14)
+then
+    modify ($account) { setBalance(-14) };
+end
+
+rule "postalCode14"
+when 
+    $address : Address(postCode != "14")
+then
+    modify ($address) { setPostCode("14") };
+end
+
+rule "accountOwner14"
+when 
+    $account : Account(balance == 14)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-14) };
+end
+
+rule "BrnoPrahaOstrava14"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "14"))
+then
+    modify ($address) { setCity("14") };
+end
+
+rule "exists14"
+when 
+    $customer: Customer(firstName == "Jake14")
+then
+    modify ($customer) {setFirstName("Jackie14")} 
+end
+
+rule "accountBalance15"
+when 
+    $account : Account(balance == 15)
+then
+    modify ($account) { setBalance(-15) };
+end
+
+rule "postalCode15"
+when 
+    $address : Address(postCode != "15")
+then
+    modify ($address) { setPostCode("15") };
+end
+
+rule "accountOwner15"
+when 
+    $account : Account(balance == 15)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-15) };
+end
+
+rule "BrnoPrahaOstrava15"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "15"))
+then
+    modify ($address) { setCity("15") };
+end
+
+rule "exists15"
+when 
+    $customer: Customer(firstName == "Jake15")
+then
+    modify ($customer) {setFirstName("Jackie15")} 
+end
+
+rule "accountBalance16"
+when 
+    $account : Account(balance == 16)
+then
+    modify ($account) { setBalance(-16) };
+end
+
+rule "postalCode16"
+when 
+    $address : Address(postCode != "16")
+then
+    modify ($address) { setPostCode("16") };
+end
+
+rule "accountOwner16"
+when 
+    $account : Account(balance == 16)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-16) };
+end
+
+rule "BrnoPrahaOstrava16"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "16"))
+then
+    modify ($address) { setCity("16") };
+end
+
+rule "exists16"
+when 
+    $customer: Customer(firstName == "Jake16")
+then
+    modify ($customer) {setFirstName("Jackie16")} 
+end
+
+rule "accountBalance17"
+when 
+    $account : Account(balance == 17)
+then
+    modify ($account) { setBalance(-17) };
+end
+
+rule "postalCode17"
+when 
+    $address : Address(postCode != "17")
+then
+    modify ($address) { setPostCode("17") };
+end
+
+rule "accountOwner17"
+when 
+    $account : Account(balance == 17)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-17) };
+end
+
+rule "BrnoPrahaOstrava17"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "17"))
+then
+    modify ($address) { setCity("17") };
+end
+
+rule "exists17"
+when 
+    $customer: Customer(firstName == "Jake17")
+then
+    modify ($customer) {setFirstName("Jackie17")} 
+end
+
+rule "accountBalance18"
+when 
+    $account : Account(balance == 18)
+then
+    modify ($account) { setBalance(-18) };
+end
+
+rule "postalCode18"
+when 
+    $address : Address(postCode != "18")
+then
+    modify ($address) { setPostCode("18") };
+end
+
+rule "accountOwner18"
+when 
+    $account : Account(balance == 18)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-18) };
+end
+
+rule "BrnoPrahaOstrava18"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "18"))
+then
+    modify ($address) { setCity("18") };
+end
+
+rule "exists18"
+when 
+    $customer: Customer(firstName == "Jake18")
+then
+    modify ($customer) {setFirstName("Jackie18")} 
+end
+
+rule "accountBalance19"
+when 
+    $account : Account(balance == 19)
+then
+    modify ($account) { setBalance(-19) };
+end
+
+rule "postalCode19"
+when 
+    $address : Address(postCode != "19")
+then
+    modify ($address) { setPostCode("19") };
+end
+
+rule "accountOwner19"
+when 
+    $account : Account(balance == 19)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-19) };
+end
+
+rule "BrnoPrahaOstrava19"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "19"))
+then
+    modify ($address) { setCity("19") };
+end
+
+rule "exists19"
+when 
+    $customer: Customer(firstName == "Jake19")
+then
+    modify ($customer) {setFirstName("Jackie19")} 
+end
+
+rule "accountBalance20"
+when 
+    $account : Account(balance == 20)
+then
+    modify ($account) { setBalance(-20) };
+end
+
+rule "postalCode20"
+when 
+    $address : Address(postCode != "20")
+then
+    modify ($address) { setPostCode("20") };
+end
+
+rule "accountOwner20"
+when 
+    $account : Account(balance == 20)
+    $customer : Customer (this == $account.owner)
+then
+    modify ($account) { setBalance(-20) };
+end
+
+rule "BrnoPrahaOstrava20"
+when 
+    $address : Address(city in ("Brno", "Praha", "Ostrava", "20"))
+then
+    modify ($address) { setCity("20") };
+end
+
+rule "exists20"
+when 
+    $customer: Customer(firstName == "Jake20")
+then
+    modify ($customer) {setFirstName("Jackie20")} 
+end

--- a/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/drl/rules_simple.drl
+++ b/drools-benchmarks-parent/drools-benchmarks-module/src/main/resources/drl/rules_simple.drl
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.simplekjar
+
+import java.util.*
+
+rule "example"
+when
+    $o: Object()
+then
+    System.out.println("Hello world");
+end
+

--- a/drools-benchmarks-parent/drools-benchmarks-quick/README.md
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/README.md
@@ -1,0 +1,43 @@
+How to run the benchmarks
+==========================
+
+The benchmarks are written using [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+
+To run the benchmarks you need to:  
+
+1. Build the project with `mvn clean install`
+2. Run the built project uberjar with `java -jar target/drools-benchmarks-quick.jar`
+
+You can define several JMH parameters for executing the benchmarks:  
+`-jvm` - Custom JVM to use when forking (path to JVM executable). JMH can create new JVM fork for a set of benchmark iterations.  
+`-jvmArgs` - Custom JVM parameters. E.g. you can specify memory consumption arguments here.    
+`-gc` - Option to force JMH to run garbage collection between benchmark iterations. Boolean parameter.  
+`-foe` - Option to determine if JMH should fail immediately if any benchmark had experienced some unrecoverable error. Boolean parameter.  
+`-wi` - Number of warmup iterations - Should be used only for "tweaking" the benchmarks run. Default value that is recommended to be used is set directly in the benchmarks' code using annotation `@Warmup`.  
+`-i` - Number of measurement iterations - Should be used only for "tweaking" the benchmarks run. Default value that is recommended to be used is set directly in the benchmarks' code using annotation `@Measurement`.  
+`-f` - Number that defines how many times should be a single benchmark forked. This defines how many JVM forks are used for measuring single benchmark. Default JMH value is 10.  
+`-rf` - Results format type. E.g. csv.  
+`-rff` - Filename to which results are written.  
+- You can also define a wildcard pattern, that specifies, which benchmarks should be run.  
+  
+**Examples**  
+  
+Running all benchmarks from `org.drools.benchmarks.quick` package and storing results in file `results.csv`:  
+  
+`java -jar target/drools-benchmarks-quick.jar -jvmArgs "-Xms4g -Xmx4g" -foe true -rf csv -rff results.csv org.drools.benchmarks.quick.*`  
+  
+Running benchmark `org.drools.benchmarks.quick.InstantiateKieContainerFromKJarBenchmark` and storing results in file `results.csv`:  
+  
+`java -jar target/drools-benchmarks-quick.jar -jvmArgs "-Xms4g -Xmx4g" -foe true -rf csv -rff results.csv org.drools.benchmarks.quick.InstantiateKieContainerFromKJarBenchmark`  
+
+
+Tips
+====
+
+It is possible to debug the single benchmarks inside IntelliJ with the [JMH Java Microbenchmark Harness](https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness) plugin. 
+There are a couple of detail to fulfill:
+1. Enable annotation processing (under Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors)
+2. set `@Fork(0)` annotation, at least during debug
+
+
+  

--- a/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
@@ -23,11 +23,6 @@
       <artifactId>drools-benchmarks-module</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-ci</artifactId>
-      <version>${version.org.drools}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
@@ -18,6 +18,16 @@
       <artifactId>drools-benchmarks-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-benchmarks-module</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-ci</artifactId>
+      <version>${version.org.drools}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -34,10 +34,10 @@ import org.openjdk.jmh.annotations.Warmup;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
-@Warmup(iterations = 20, time = 3)
-@Measurement(iterations = 20, time = 3)
+@Warmup(iterations = 10, time = 3)
+@Measurement(iterations = 10, time = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(4)
+@Fork(3)
 public class InstantiateKieContainerFromKJarBenchmark {
 
     private static final String MODULE_GROUPID ="org.drools";

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -50,7 +50,7 @@ public class InstantiateKieContainerFromKJarBenchmark {
 
     @Benchmark
     public KieBase createKieContainerFromKjar()  {
-        KieContainer kieContainer = KieServices.get().newKieContainer(MODULE_RELEASEID, Thread.currentThread().getContextClassLoader());
+        KieContainer kieContainer = KieServices.get().newKieContainer(MODULE_RELEASEID);
         return kieContainer.getKieBase(MODULE_KIEBASE);
     }
 

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -33,8 +33,8 @@ import org.openjdk.jmh.annotations.Warmup;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
-@Warmup(iterations = 10, time = 3)
-@Measurement(iterations = 10, time = 3)
+@Warmup(iterations = 15, time = 3)
+@Measurement(iterations = 5, time = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(3)
 public class InstantiateKieContainerFromKJarBenchmark {

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
-import org.kie.api.runtime.KieContainer;
 import org.kie.util.maven.support.ReleaseIdImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -50,8 +49,7 @@ public class InstantiateKieContainerFromKJarBenchmark {
 
     @Benchmark
     public KieBase createKieContainerFromKjar()  {
-        KieContainer kieContainer = KieServices.get().newKieContainer(MODULE_RELEASEID);
-        return kieContainer.getKieBase(MODULE_KIEBASE);
+        return KieServices.get().newKieContainer(MODULE_RELEASEID).getKieBase(MODULE_KIEBASE);
     }
 
 

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.benchmarks.quick;
+
+import java.util.concurrent.TimeUnit;
+
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
+import org.kie.util.maven.support.ReleaseIdImpl;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 20, time = 3)
+@Measurement(iterations = 20, time = 3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(4)
+public class InstantiateKieContainerFromKJarBenchmark {
+
+    private static final String MODULE_GROUPID ="org.drools";
+    private static final String MODULE_ARTIFACTID ="drools-benchmarks-module";
+    private static final String MODULE_VERSION ="1.0-SNAPSHOT";
+
+    private static final String MODULE_KIEBASE ="benchmarks-module";
+
+    private static final ReleaseId MODULE_RELEASEID = new  ReleaseIdImpl(MODULE_GROUPID, MODULE_ARTIFACTID, MODULE_VERSION);
+
+    @Benchmark
+    public KieBase createKieContainerFromKjar()  {
+        KieContainer kieContainer = KieServices.get().newKieContainer(MODULE_RELEASEID, Thread.currentThread().getContextClassLoader());
+        return kieContainer.getKieBase(MODULE_KIEBASE);
+    }
+
+
+}

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/resources/logback.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+
+
+<configuration debug="true">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are  by default assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>
+
+
+

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/resources/logback.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/resources/logback.xml
@@ -1,5 +1,3 @@
-
-
 <configuration debug="true">
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -9,6 +7,10 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
+
+  <logger name="org.kie" level="ERROR"/>
+  <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
+  <logger name="org.drools" level="ERROR"/>
 
   <root level="info">
     <appender-ref ref="STDOUT" />

--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -24,6 +24,7 @@
     <module>drools-benchmarks-common</module>
     <module>drools-benchmarks-quick</module>
     <module>drools-benchmarks</module>
+    <module>drools-benchmarks-module</module>
   </modules>
 
   <dependencyManagement>

--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -118,10 +118,6 @@
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes https://github.com/kiegroup/kie-issues/issues/53

@baldimir @danielezonca @hellowdan 

This PR

1. creates a stand-alone "drools-benchmarks-module" to be used for benchmarks
2. creates `InstantiateKieContainerFromKJarBenchmark` to measure instantiation time of `KieContainer`

Notes:

1.  `KieServices.newKieContainer(ReleaseId releaseId, ClassLoader classLoader)` has been used because, locally, the usage of `KieServices.newKieContainer(ReleaseId releaseId);` throws `ArtifactNotFoundExcpetions` inside JHM; apparently, in that case `MavenClassLoaderResolver`  does not properly replace version placeholders
2.  `KieContainer.getKieBase(String kBaseName)`  is invoked to verify that the required module has actually been found and loaded