### PR TITLE
[kie-issues#52] WIP - Quick kjar build-time

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/CommonProperties.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/CommonProperties.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.benchmarks.quick;
+
+import org.kie.api.builder.ReleaseId;
+import org.kie.util.maven.support.ReleaseIdImpl;
+
+public class CommonProperties {
+
+    private CommonProperties() {
+        //Avoid instantiation
+    }
+
+    public static final String MODULE_GROUPID ="org.drools";
+    public static final String MODULE_ARTIFACTID ="drools-benchmarks-module";
+    public static final String MODULE_VERSION ="1.0-SNAPSHOT";
+
+    public static final String MODULE_KIEBASE ="benchmarks-module";
+
+    public static final ReleaseId MODULE_RELEASEID = new ReleaseIdImpl(MODULE_GROUPID, MODULE_ARTIFACTID, MODULE_VERSION);
+}

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
@@ -16,11 +16,6 @@
 package org.drools.benchmarks.quick;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 
 import org.drools.benchmarks.common.util.BuildtimeUtil;
@@ -56,43 +51,19 @@ public class InstantiateKJarBenchmark {
 
     @Setup(Level.Trial)
     public void loadResources() {
-        URL dmnResource = Thread.currentThread().getContextClassLoader().getResource("dmn/Traffic Violation.dmn");
-        if (dmnResource == null) {
-            throw new RuntimeException("Failed to find dmn file");
-        }
-        String dmnContent = readStringFromURL(dmnResource);
-        URL drlResource = Thread.currentThread().getContextClassLoader().getResource("drl/rules.drl");
-        if (drlResource == null) {
-            throw new RuntimeException("Failed to find drl file");
-        }
-        String drlContent = readStringFromURL(drlResource);
-        KieResources kieResources = KieServices.get().getResources();
-        List<Resource> resourceList  = new ArrayList<>();
-        Resource toAdd = kieResources.newByteArrayResource(dmnContent.getBytes())
+        KieResources kieResourcesresources = KieServices.get().getResources();
+        this.resources = new Resource[2];
+        resources[0] = kieResourcesresources.newClassPathResource("dmn/Traffic Violation.dmn")
                 .setResourceType(ResourceType.DMN)
                 .setSourcePath("Traffic Violation.dmn");
-        resourceList.add(toAdd);
-        toAdd = kieResources.newByteArrayResource(drlContent.getBytes())
+        resources[1] = kieResourcesresources.newClassPathResource("drl/rules.drl")
                 .setResourceType(ResourceType.DRL)
                 .setSourcePath("rules.drl");
-        resourceList.add(toAdd);
-        resources = resourceList.toArray(new Resource[0]);
     }
 
     @Benchmark
     public ReleaseId createKieJarFromResources() throws IOException {
         return BuildtimeUtil.createKJarFromResources(useCanonicalModel, resources);
-    }
-
-    private static String readStringFromURL(URL url) {
-        try (Scanner scanner = new Scanner(url.openStream(),
-                                           StandardCharsets.UTF_8.toString()))
-        {
-            scanner.useDelimiter("\\A");
-            return scanner.hasNext() ? scanner.next() : "";
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
 }

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
@@ -51,12 +51,12 @@ public class InstantiateKJarBenchmark {
 
     @Setup(Level.Trial)
     public void loadResources() {
-        KieResources kieResourcesresources = KieServices.get().getResources();
+        KieResources kieResources = KieServices.get().getResources();
         this.resources = new Resource[2];
-        resources[0] = kieResourcesresources.newClassPathResource("dmn/Traffic Violation.dmn")
+        resources[0] = kieResources.newClassPathResource("dmn/Traffic Violation.dmn")
                 .setResourceType(ResourceType.DMN)
                 .setSourcePath("Traffic Violation.dmn");
-        resources[1] = kieResourcesresources.newClassPathResource("drl/rules.drl")
+        resources[1] = kieResources.newClassPathResource("drl/rules.drl")
                 .setResourceType(ResourceType.DRL)
                 .setSourcePath("rules.drl");
     }

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKJarBenchmark.java
@@ -48,7 +48,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 4, time = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(3)
-public class InstantiateKieJarBenchmark {
+public class InstantiateKJarBenchmark {
 
     @Param({"true", "false"})
     private boolean useCanonicalModel;

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -19,8 +19,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
-import org.kie.api.builder.ReleaseId;
-import org.kie.util.maven.support.ReleaseIdImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -31,6 +29,9 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import static org.drools.benchmarks.quick.CommonProperties.MODULE_KIEBASE;
+import static org.drools.benchmarks.quick.CommonProperties.MODULE_RELEASEID;
+
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 15, time = 3)
@@ -39,13 +40,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(3)
 public class InstantiateKieContainerFromKJarBenchmark {
 
-    private static final String MODULE_GROUPID ="org.drools";
-    private static final String MODULE_ARTIFACTID ="drools-benchmarks-module";
-    private static final String MODULE_VERSION ="1.0-SNAPSHOT";
-
-    private static final String MODULE_KIEBASE ="benchmarks-module";
-
-    private static final ReleaseId MODULE_RELEASEID = new  ReleaseIdImpl(MODULE_GROUPID, MODULE_ARTIFACTID, MODULE_VERSION);
 
     @Benchmark
     public KieBase createKieContainerFromKjar()  {

--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieJarBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.benchmarks.quick;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.drools.benchmarks.common.util.BuildtimeUtil;
+import org.drools.util.ResourceHelper;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.io.KieResources;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 15, time = 3)
+@Measurement(iterations = 5, time = 3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class InstantiateKieJarBenchmark {
+
+    @Param({"true", "false"})
+    private boolean useCanonicalModel;
+    private Resource[] resources;
+
+
+    @Setup
+    public void loadResources() throws IOException {
+        KieResources kieResources = KieServices.get().getResources();
+        Collection<File> dmns = ResourceHelper.getFileResourcesByExtension("dmn");
+        Collection<File> drls = ResourceHelper.getFileResourcesByExtension("drl");
+        List<Resource> resourceList  = new ArrayList<>();
+
+        for (File dmn : dmns) {
+            Resource toAdd = kieResources.newByteArrayResource(Files.readString(dmn.toPath()).getBytes(StandardCharsets.UTF_8))
+                    .setResourceType(ResourceType.DMN)
+                    .setSourcePath(dmn.getName());
+            resourceList.add(toAdd);
+        }
+        for (File drl : drls) {
+            Resource toAdd = kieResources.newByteArrayResource(Files.readString(drl.toPath()).getBytes(StandardCharsets.UTF_8))
+                    .setResourceType(ResourceType.DRL)
+                    .setSourcePath(drl.getName());
+            resourceList.add(toAdd);
+        }
+        resources = resourceList.toArray(new Resource[0]);
+    }
+
+    @Benchmark
+    public ReleaseId createKieJarFromResources() throws IOException {
+        return BuildtimeUtil.createKJarFromResources(useCanonicalModel, resources);
+    }
+
+
+}


### PR DESCRIPTION
@baldimir @mariofusco  @danielezonca 

Fixes https://github.com/kiegroup/kie-issues/issues/52

I've implemented `InstantiateKieJarBenchmark` following code from `BuildKJarFromResourceBenchmark`

The `Setup` phase read file content as string and uses `ByteArrayResource` to avoid possible unrelated IO issues during benchmark execution
