### PR TITLE
Revert "bumped up Optaplanner version to next SNAPSHOT"

### DIFF
--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <version.compiler>3.8.0</version.compiler>
     <maven.versions.plugin>2.8.1</maven.versions.plugin>
-    <version.org.optaplanner>9.36.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.36.0-SNAPSHOT</version.org.optaplanner>
   </properties>
 
   <modules>


### PR DESCRIPTION
Reverts kiegroup/kie-benchmarks#223

wrongly upgraded by OptaPlanner setup-branch 9.35.x