### PR TITLE
bumped up Optaplanner version to next SNAPSHOT

### DIFF
--- a/optaplanner-benchmarks/pom.xml
+++ b/optaplanner-benchmarks/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <version.compiler>3.8.0</version.compiler>
     <maven.versions.plugin>2.8.1</maven.versions.plugin>
-    <version.org.optaplanner>8.36.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.37.0-SNAPSHOT</version.org.optaplanner>
   </properties>
 
   <modules>


### PR DESCRIPTION
Generated by build jenkins-KIE-optaplanner-main-setup-branch-optaplanner-9: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/main/job/setup-branch/job/optaplanner/9/