### PR TITLE
[DROOLS-7361] Add benchmarks for drools-reliability

### DIFF
--- a/drools-benchmarks-parent/README.md
+++ b/drools-benchmarks-parent/README.md
@@ -10,6 +10,8 @@ This module contains multiple Maven modules. The instructions how to run individ
   - Quick benchmarks that are supposed to be used for initial sanity measurements. 
 - drools-benchmarks-common
   - Module that contains common classes shared between different Drools benchmark modules. 
+- drools-benchmarks-reliability
+  - Benchmarks for session reliability feature. 
 
 
   

--- a/drools-benchmarks-parent/drools-benchmarks-common/src/main/java/org/drools/benchmarks/common/model/AbstractBean.java
+++ b/drools-benchmarks-parent/drools-benchmarks-common/src/main/java/org/drools/benchmarks/common/model/AbstractBean.java
@@ -15,9 +15,11 @@
 
 package org.drools.benchmarks.common.model;
 
+import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 
-public abstract class AbstractBean {
+public abstract class AbstractBean implements Serializable {
+
     private static final AtomicLong idGenerator = new AtomicLong( 0 );
 
     private final long id;

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/.gitignore
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/.gitignore
@@ -1,0 +1,27 @@
+/target
+/local
+/bin
+
+*.class
+
+# drools-reliability-infinispan
+global/
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/README.md
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/README.md
@@ -1,0 +1,43 @@
+How to run the benchmarks
+==========================
+
+The benchmarks are written using [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+
+To run the benchmarks you need to:  
+
+1. Build the project with `mvn clean install`
+2. Run the built project uberjar with `java -jar target/drools-benchmarks-reliability.jar`
+
+You can define several JMH parameters for executing the benchmarks:  
+`-jvm` - Custom JVM to use when forking (path to JVM executable). JMH can create new JVM fork for a set of benchmark iterations.  
+`-jvmArgs` - Custom JVM parameters. E.g. you can specify memory consumption arguments here.    
+`-gc` - Option to force JMH to run garbage collection between benchmark iterations. Boolean parameter.  
+`-foe` - Option to determine if JMH should fail immediately if any benchmark had experienced some unrecoverable error. Boolean parameter.  
+`-wi` - Number of warmup iterations - Should be used only for "tweaking" the benchmarks run. Default value that is recommended to be used is set directly in the benchmarks' code using annotation `@Warmup`.  
+`-i` - Number of measurement iterations - Should be used only for "tweaking" the benchmarks run. Default value that is recommended to be used is set directly in the benchmarks' code using annotation `@Measurement`.  
+`-f` - Number that defines how many times should be a single benchmark forked. This defines how many JVM forks are used for measuring single benchmark. Default JMH value is 10.  
+`-rf` - Results format type. E.g. csv.  
+`-rff` - Filename to which results are written.  
+- You can also define a wildcard pattern, that specifies, which benchmarks should be run.  
+  
+**Examples**  
+  
+Running all benchmarks from `org.drools.benchmarks.reliability` package and storing results in file `results.csv`:  
+  
+`java -jar target/drools-benchmarks-reliability.jar -jvmArgs "-Xms4g -Xmx4g" -foe true -rf csv -rff results.csv org.drools.benchmarks.reliability.*`  
+  
+Running benchmark `org.drools.benchmarks.reliability.InsertOnlyBenchmark` and storing results in file `results.csv`:  
+  
+`java -jar target/drools-benchmarks-reliability.jar -jvmArgs "-Xms4g -Xmx4g" -foe true -rf csv -rff results.csv org.drools.benchmarks.reliability.InsertOnlyBenchmark`  
+
+
+Tips
+====
+
+It is possible to debug the single benchmarks inside IntelliJ with the [JMH Java Microbenchmark Harness](https://plugins.jetbrains.com/plugin/7529-jmh-java-microbenchmark-harness) plugin. 
+There are a couple of detail to fulfill:
+1. Enable annotation processing (under Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors)
+2. set `@Fork(0)` annotation, at least during debug
+
+
+  

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>drools-benchmarks-parent</artifactId>
+    <groupId>org.drools</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>drools-benchmarks-reliability</artifactId>
+  <name>Drools 8 Benchmarks comparing reliability performance</name>
+
+  <properties>
+    <version.infinispan>14.0.6.Final</version.infinispan>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-bom</artifactId>
+        <version>${version.infinispan}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-benchmarks-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-benchmarks-module</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-reliability-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-reliability-infinispan</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-server-testdriver-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-jboss-marshalling</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>drools-benchmarks-reliability</finalName>
+              <transformers>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                      <resource>META-INF/kie.conf</resource>
+                  </transformer>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>org.openjdk.jmh.Main</mainClass>
+                  </transformer>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/AbstractReliabilityBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/AbstractReliabilityBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.reliability;
+
+import java.nio.file.Path;
+
+import org.drools.benchmarks.common.AbstractBenchmark;
+import org.drools.benchmarks.common.util.RuntimeUtil;
+import org.drools.reliability.core.CacheManagerFactory;
+import org.drools.reliability.infinispan.EmbeddedCacheManager;
+import org.drools.reliability.infinispan.InfinispanCacheManager;
+import org.drools.util.FileUtils;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.server.test.core.InfinispanContainer;
+import org.kie.api.runtime.conf.PersistedSessionOption;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+import static org.drools.benchmarks.reliability.AbstractReliabilityBenchmark.Mode.NONE;
+import static org.drools.benchmarks.reliability.AbstractReliabilityBenchmark.Mode.REMOTE;
+
+public abstract class AbstractReliabilityBenchmark extends AbstractBenchmark {
+
+    // The enum names have to match CacheManagerFactory.RELIABILITY_CACHE_MODE values apart from "NONE"
+    public enum Mode {
+        NONE,
+        EMBEDDED,
+        REMOTE
+    }
+
+    @Param({"NONE", "EMBEDDED", "REMOTE"})
+    private Mode mode;
+
+    private InfinispanContainer container;
+
+    @Setup
+    public void setupEnvironment() {
+        if (mode != NONE) {
+            FileUtils.deleteDirectory(Path.of(EmbeddedCacheManager.GLOBAL_STATE_DIR));
+            System.setProperty(CacheManagerFactory.RELIABILITY_CACHE_MODE, mode.name());
+            System.setProperty(CacheManagerFactory.RELIABILITY_CACHE_ALLOWED_PACKAGES, "org.drools.benchmarks.common.model");
+        }
+
+        if (mode == REMOTE) {
+            container = new InfinispanContainer();
+            container.start();
+            InfinispanCacheManager cacheManager = (InfinispanCacheManager) CacheManagerFactory.get().getCacheManager();
+            RemoteCacheManager remoteCacheManager = container.getRemoteCacheManager(cacheManager.provideAdditionalRemoteConfigurationBuilder());
+            cacheManager.setRemoteCacheManager(remoteCacheManager);
+        }
+    }
+
+    @TearDown
+    public void tearDownEnvironment() {
+        if (mode == REMOTE) {
+            CacheManagerFactory.get().getCacheManager().close();
+            container.stop();
+        }
+    }
+
+    @Setup(Level.Iteration)
+    @Override
+    public void setup() {
+        if (mode != NONE) {
+            kieSession = RuntimeUtil.createKieSession(kieBase, PersistedSessionOption.newSession(PersistedSessionOption.Strategy.STORES_ONLY));
+        } else {
+            kieSession = RuntimeUtil.createKieSession(kieBase);
+        }
+
+        populateKieSessionPerIteration();
+    }
+
+    protected abstract void populateKieSessionPerIteration();
+}

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/FireOnlyBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/FireOnlyBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.reliability;
+
+import org.drools.benchmarks.common.DRLProvider;
+import org.drools.benchmarks.common.model.A;
+import org.drools.benchmarks.common.model.B;
+import org.drools.benchmarks.common.providers.RulesWithJoinsProvider;
+import org.drools.benchmarks.common.util.BuildtimeUtil;
+import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.internal.conf.MultithreadEvaluationOption;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 2000)
+@Measurement(iterations = 1000)
+public class FireOnlyBenchmark extends AbstractReliabilityBenchmark {
+
+    @Param({"192"})
+    private int rulesNr;
+
+    @Param({"10", "100", "1000"})
+    private int factsNr;
+
+    @Setup
+    public void setupKieBase() {
+        final DRLProvider drlProvider = new RulesWithJoinsProvider(1, false, true);
+        kieBase = BuildtimeUtil.createKieBaseFromDrl(drlProvider.getDrl(rulesNr),
+                                                     MultithreadEvaluationOption.NO,
+                                                     EventProcessingOption.CLOUD);
+    }
+
+    @Override
+    public void populateKieSessionPerIteration() {
+        StatefulKnowledgeSessionImpl session = (StatefulKnowledgeSessionImpl) kieSession;
+        A a = new A(rulesNr + 1);
+
+        session.insert(a);
+
+        for (int i = 0; i < factsNr; i++) {
+            session.insert(new B(rulesNr + i + 3));
+        }
+    }
+
+    @Benchmark
+    public int test() {
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertOnlyBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertOnlyBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.reliability;
+
+import org.drools.benchmarks.common.DRLProvider;
+import org.drools.benchmarks.common.model.A;
+import org.drools.benchmarks.common.model.B;
+import org.drools.benchmarks.common.model.C;
+import org.drools.benchmarks.common.model.D;
+import org.drools.benchmarks.common.providers.RulesWithJoinsProvider;
+import org.drools.benchmarks.common.util.BuildtimeUtil;
+import org.drools.kiesession.session.StatefulKnowledgeSessionImpl;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.internal.conf.MultithreadEvaluationOption;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 3000)
+@Measurement(iterations = 1000)
+public class InsertOnlyBenchmark extends AbstractReliabilityBenchmark {
+
+    @Param({"768"})
+    private int rulesNr;
+
+    @Param({"10", "100", "1000"})
+    private int factsNr;
+
+    @Param({"3"})
+    private int joinsNr;
+
+    @Setup
+    public void setupKieBase() {
+        final DRLProvider drlProvider = new RulesWithJoinsProvider(joinsNr, false, true);
+        kieBase = BuildtimeUtil.createKieBaseFromDrl(drlProvider.getDrl(rulesNr),
+                                                     MultithreadEvaluationOption.NO,
+                                                     EventProcessingOption.CLOUD);
+    }
+
+    @Override
+    public void populateKieSessionPerIteration() {
+        // no op
+    }
+
+    @Benchmark
+    public void test(final Blackhole eater) {
+        StatefulKnowledgeSessionImpl session = (StatefulKnowledgeSessionImpl) kieSession;
+        eater.consume(session.insert(new A(rulesNr + 1)));
+        for (int i = 0; i < factsNr; i++) {
+            eater.consume(session.insert(new B(rulesNr + i + 3)));
+            if (joinsNr > 1) {
+                eater.consume(session.insert(new C(rulesNr + factsNr + i + 3)));
+            }
+            if (joinsNr > 2) {
+                eater.consume(session.insert(new D(rulesNr + factsNr * 2 + i + 3)));
+            }
+        }
+    }
+}

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/resources/logback.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration debug="true">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are  by default assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="ERROR"/>
+  <logger name="org.drools.compiler.kie.builder.impl" level="ERROR" />
+  <logger name="org.drools" level="ERROR"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>
+
+
+

--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -25,6 +25,7 @@
     <module>drools-benchmarks-quick</module>
     <module>drools-benchmarks</module>
     <module>drools-benchmarks-module</module>
+    <module>drools-benchmarks-reliability</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
Local test results
```
Benchmark                 (factsNr)  (joinsNr)    (mode)  (rulesNr)  Mode  Cnt    Score   Error  Units
FireOnlyBenchmark.test           10        N/A      NONE        192    ss  200    1.474 ± 0.090  ms/op
FireOnlyBenchmark.test           10        N/A  EMBEDDED        192    ss  200    2.408 ± 0.117  ms/op
FireOnlyBenchmark.test           10        N/A    REMOTE        192    ss  200    2.842 ± 0.235  ms/op
FireOnlyBenchmark.test          100        N/A      NONE        192    ss  200    4.901 ± 0.216  ms/op
FireOnlyBenchmark.test          100        N/A  EMBEDDED        192    ss  200    7.799 ± 0.201  ms/op
FireOnlyBenchmark.test          100        N/A    REMOTE        192    ss  200   12.299 ± 0.287  ms/op
FireOnlyBenchmark.test         1000        N/A      NONE        192    ss  200   35.917 ± 0.697  ms/op
FireOnlyBenchmark.test         1000        N/A  EMBEDDED        192    ss  200   70.993 ± 0.749  ms/op
FireOnlyBenchmark.test         1000        N/A    REMOTE        192    ss  200  102.626 ± 1.135  ms/op
InsertOnlyBenchmark.test         10          3      NONE        768    ss  200    0.042 ± 0.003  ms/op
InsertOnlyBenchmark.test         10          3  EMBEDDED        768    ss  200    2.396 ± 0.207  ms/op
InsertOnlyBenchmark.test         10          3    REMOTE        768    ss  200    2.632 ± 0.085  ms/op
InsertOnlyBenchmark.test        100          3      NONE        768    ss  200    0.159 ± 0.007  ms/op
InsertOnlyBenchmark.test        100          3  EMBEDDED        768    ss  200   12.889 ± 0.208  ms/op
InsertOnlyBenchmark.test        100          3    REMOTE        768    ss  200   20.155 ± 0.478  ms/op
InsertOnlyBenchmark.test       1000          3      NONE        768    ss  200    1.106 ± 0.159  ms/op
InsertOnlyBenchmark.test       1000          3  EMBEDDED        768    ss  200  135.086 ± 2.161  ms/op
InsertOnlyBenchmark.test       1000          3    REMOTE        768    ss  200  178.414 ± 2.866  ms/op
```