### PR TITLE
Make all JMH regression tests parameterized

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/src/main/java/org/drools/benchmarks/quick/InstantiateKieContainerFromKJarBenchmark.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -40,6 +41,8 @@ import static org.drools.benchmarks.quick.CommonProperties.MODULE_RELEASEID;
 @Fork(3)
 public class InstantiateKieContainerFromKJarBenchmark {
 
+    @Param({"instantiation"})
+    private String param;
 
     @Benchmark
     public KieBase createKieContainerFromKjar()  {

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDTablesBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDTablesBenchmark.java
@@ -17,6 +17,7 @@
 package org.drools.benchmarks.turtle.buildtime;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 
 /**
@@ -24,6 +25,10 @@ import org.openjdk.jmh.annotations.Setup;
  * (several thousands of rules) decision tables.
  */
 public class KBaseCreationFromDTablesBenchmark extends AbstractBuildtimeBenchmark {
+
+
+    @Param({"298r"})
+    private String dataset;
 
     @Setup
     public void addResources() {

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDslAndDslrBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromDslAndDslrBenchmark.java
@@ -17,12 +17,16 @@
 package org.drools.benchmarks.turtle.buildtime;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 
 /**
  * Tests how long it takes to create knowledge base from DSL and DSLR files.
  */
 public class KBaseCreationFromDslAndDslrBenchmark extends AbstractBuildtimeBenchmark {
+
+    @Param({"5000dslr-3dsl"})
+    private String dataset;
 
     @Setup
     public void addResources() {

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromMultipleResourcesBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/buildtime/KBaseCreationFromMultipleResourcesBenchmark.java
@@ -17,6 +17,7 @@
 package org.drools.benchmarks.turtle.buildtime;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -27,6 +28,9 @@ import org.openjdk.jmh.annotations.State;
  */
 @State(Scope.Benchmark)
 public class KBaseCreationFromMultipleResourcesBenchmark extends AbstractBuildtimeBenchmark {
+
+    @Param({"1000drl"})
+    private String dataset;
 
     @Setup
     public void addResources() {


### PR DESCRIPTION
To have consistent jmh results to parse later each benchmark needs to have parameter value.