### PR TITLE
Param fix for runtime benchmarks

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertAndFireBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertAndFireBenchmark.java
@@ -73,4 +73,6 @@ public class InsertAndFireBenchmark extends AbstractReliabilityBenchmark {
         }
         return kieSession.fireAllRules();
     }
+
+
 }

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertAndFireBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/src/main/java/org/drools/benchmarks/reliability/InsertAndFireBenchmark.java
@@ -73,6 +73,4 @@ public class InsertAndFireBenchmark extends AbstractReliabilityBenchmark {
         }
         return kieSession.fireAllRules();
     }
-
-
 }

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators2ExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators2ExpertBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -45,6 +46,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AdvOperators2ExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
 
+    @Param({"200000"})
+    int nrOfFacts;
+
     @Override
     protected void addResources() {
         addClassPathResource("turtle/expert-advanced-operators2-100.drl");
@@ -52,7 +56,7 @@ public class AdvOperators2ExpertBenchmark extends AbstractSimpleRuntimeBenchmark
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new AdvancedOperators2FactsGenerator(getGeneratorConfiguration()), 200000);
+        addFactsGenerator(new AdvancedOperators2FactsGenerator(getGeneratorConfiguration()), nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators3ExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators3ExpertBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -46,6 +47,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AdvOperators3ExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
 
+    @Param({"200000"})
+    int nrOfFacts;
+
     @Override
     protected void addResources() {
         addClassPathResource("turtle/expert-advanced-operators3-100.drl");
@@ -53,7 +57,7 @@ public class AdvOperators3ExpertBenchmark extends AbstractSimpleRuntimeBenchmark
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new AdvancedOperators3FactsGenerator(getGeneratorConfiguration()),200000);
+        addFactsGenerator(new AdvancedOperators3FactsGenerator(getGeneratorConfiguration()), nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators4ExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperators4ExpertBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -45,6 +46,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AdvOperators4ExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
 
+    @Param({"200000"})
+    int nrOfFacts;
+
     @Override
     protected void addResources() {
         addClassPathResource("turtle/expert-advanced-operators4-100.drl");
@@ -52,7 +56,7 @@ public class AdvOperators4ExpertBenchmark extends AbstractSimpleRuntimeBenchmark
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new AdvancedOperators4FactsGenerator(getGeneratorConfiguration()),200000);
+        addFactsGenerator(new AdvancedOperators4FactsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperatorsExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AdvOperatorsExpertBenchmark.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -45,6 +46,9 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AdvOperatorsExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
 
+    @Param({"200000"})
+    int nrOfFacts;
+
     @Override
     protected void addResources() {
         addClassPathResource("turtle/expert-advanced-operators-100.drl");
@@ -52,7 +56,7 @@ public class AdvOperatorsExpertBenchmark extends AbstractSimpleRuntimeBenchmark 
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new AdvancedOperatorsFactsGenerator(getGeneratorConfiguration()),200000);
+        addFactsGenerator(new AdvancedOperatorsFactsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AfterBeforeFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AfterBeforeFusionBenchmark.java
@@ -24,9 +24,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class AfterBeforeFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
 
+    @Param({"200000"})
+    int nrOfFacts;
     @Override
     public void addResources() {
         addClassPathResource("turtle/fusion-after-before-operators-100.drl");
@@ -34,7 +37,7 @@ public class AfterBeforeFusionBenchmark extends AbstractSimpleFusionRuntimeBench
 
     @Override
     public void addEventSenders() {
-        addEventSender(new AfterBeforeEventsGenerator(getGeneratorConfiguration()),200000);
+        addEventSender(new AfterBeforeEventsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AfterBeforeFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/AfterBeforeFusionBenchmark.java
@@ -30,6 +30,7 @@ public class AfterBeforeFusionBenchmark extends AbstractSimpleFusionRuntimeBench
 
     @Param({"200000"})
     int nrOfFacts;
+    
     @Override
     public void addResources() {
         addClassPathResource("turtle/fusion-after-before-operators-100.drl");

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/CoincidesDuringFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/CoincidesDuringFusionBenchmark.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Param;
 public class CoincidesDuringFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
     @Param({"50000"})
     int nrOfEvents;
+    
     @Override
     public void addResources() {
         addClassPathResource("turtle/fusion-coincides-during-operators-100.drl");

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/CoincidesDuringFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/CoincidesDuringFusionBenchmark.java
@@ -24,9 +24,11 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class CoincidesDuringFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
-
+    @Param({"50000"})
+    int nrOfEvents;
     @Override
     public void addResources() {
         addClassPathResource("turtle/fusion-coincides-during-operators-100.drl");
@@ -34,7 +36,7 @@ public class CoincidesDuringFusionBenchmark extends AbstractSimpleFusionRuntimeB
 
     @Override
     public void addEventSenders() {
-        addEventSender(new CoincidesDuringEventsGenerator(getGeneratorConfiguration()),50000);
+        addEventSender(new CoincidesDuringEventsGenerator(getGeneratorConfiguration()), nrOfEvents);
     }
 
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable1Benchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable1Benchmark.java
@@ -39,7 +39,7 @@ public class DTable1Benchmark extends AbstractSimpleRuntimeBenchmark {
     }
 
     public enum DTableFactRange {
-        MEDIUM_DTABLE1("kbase-creation/dtable1-kbase-creation.xls", 999,3102);
+        FROM999_TO3102_DTABLE1("kbase-creation/dtable1-kbase-creation.xls", 999,3102);
 
         DTableFactRange(String file, int from, int to) {
             this.filename = file;

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable1Benchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable1Benchmark.java
@@ -3,6 +3,7 @@ package org.drools.benchmarks.turtle.runtime;
 import org.drools.benchmarks.common.model.Account;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -13,13 +14,12 @@ import java.util.List;
 @Warmup(iterations = 100000)
 @Measurement(iterations = 10000)
 public class DTable1Benchmark extends AbstractSimpleRuntimeBenchmark {
-
-    private static int from = 999;
-    private static int to = 3102;
+    @Param("FROM999_TO3102_DTABLE1")
+    DTableFactRange range;
 
     @Setup
     public void addResources() {
-        addClassPathResource("kbase-creation/dtable1-kbase-creation.xls");
+        addClassPathResource(range.getFilename());
     }
 
     @Benchmark
@@ -30,12 +30,40 @@ public class DTable1Benchmark extends AbstractSimpleRuntimeBenchmark {
     @Override
     protected List<Object> generateFacts() {
         List<Object> facts = new ArrayList<Object>();
-        for (int i = from; i < to; i++) {
+        for (int i = range.getFrom(); i < range.getTo(); i++) {
             Account account = new Account();
             account.setNumber(i);
             facts.add(account);
         }
         return facts;
+    }
+
+    public enum DTableFactRange {
+        MEDIUM_DTABLE1("kbase-creation/dtable1-kbase-creation.xls", 999,3102);
+
+        DTableFactRange(String file, int from, int to) {
+            this.filename = file;
+            this.to = to;
+            this.from = from;
+        }
+
+        private String filename;
+
+        private int from;
+
+        private int to;
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public int getFrom() {
+            return from;
+        }
+
+        public int getTo() {
+            return to;
+        }
     }
 
 }

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable2Benchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/DTable2Benchmark.java
@@ -4,6 +4,7 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.KBaseCreationFromDTable2Generator;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -12,6 +13,9 @@ import org.openjdk.jmh.annotations.Benchmark;
 @Measurement(iterations = 200)
 public class DTable2Benchmark extends AbstractSimpleRuntimeBenchmark {
 
+    @Param({"20000"})
+    int nrOfFacts;
+
     @Setup
     public void addResources() {
         addClassPathResource("kbase-creation/dtable2-kbase-creation.xls");
@@ -19,7 +23,7 @@ public class DTable2Benchmark extends AbstractSimpleRuntimeBenchmark {
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new KBaseCreationFromDTable2Generator(getGeneratorConfiguration()),20000);
+        addFactsGenerator(new KBaseCreationFromDTable2Generator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/FinishesFinishedbyFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/FinishesFinishedbyFusionBenchmark.java
@@ -24,8 +24,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class FinishesFinishedbyFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
+
+    @Param({"50000"})
+    int nrOfEvents;
 
     @Override
     public void addResources() {
@@ -34,7 +38,7 @@ public class FinishesFinishedbyFusionBenchmark extends AbstractSimpleFusionRunti
 
     @Override
     public void addEventSenders() {
-        addEventSender(new FinishesFinishedbyEventsGenerator(getGeneratorConfiguration()),50000);
+        addEventSender(new FinishesFinishedbyEventsGenerator(getGeneratorConfiguration()),nrOfEvents);
     }
 
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/InsertFactsIntoWmExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/InsertFactsIntoWmExpertBenchmark.java
@@ -23,8 +23,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class InsertFactsIntoWmExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"2000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -33,7 +37,7 @@ public class InsertFactsIntoWmExpertBenchmark extends AbstractSimpleRuntimeBench
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new BasicInsertFactsIntoWmFactsGenerator(getGeneratorConfiguration()),2000);
+        addFactsGenerator(new BasicInsertFactsIntoWmFactsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/InsertLogicalFactsIntoWmExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/InsertLogicalFactsIntoWmExpertBenchmark.java
@@ -23,8 +23,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class InsertLogicalFactsIntoWmExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"5000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -33,7 +37,7 @@ public class InsertLogicalFactsIntoWmExpertBenchmark extends AbstractSimpleRunti
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new BasicInsertLogicalFactsIntoWmFactsGenerator(getGeneratorConfiguration()),5000);
+        addFactsGenerator(new BasicInsertLogicalFactsIntoWmFactsGenerator(getGeneratorConfiguration()), nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/MeetsMetbyFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/MeetsMetbyFusionBenchmark.java
@@ -24,8 +24,12 @@ import org.drools.benchmarks.turtle.runtime.generator.MeetsMetbyEventsGenerator;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class MeetsMetbyFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
+
+    @Param({"50000"})
+    int nrOfEvents;
 
     @Override
     public void addResources() {
@@ -34,7 +38,7 @@ public class MeetsMetbyFusionBenchmark extends AbstractSimpleFusionRuntimeBenchm
 
     @Override
     public void addEventSenders() {
-        addEventSender(new MeetsMetbyEventsGenerator(getGeneratorConfiguration()),50000);
+        addEventSender(new MeetsMetbyEventsGenerator(getGeneratorConfiguration()),nrOfEvents);
     }
 
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/OverlapsOverlappedbyFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/OverlapsOverlappedbyFusionBenchmark.java
@@ -24,8 +24,12 @@ import org.drools.benchmarks.turtle.runtime.generator.OverlapsOverlappedbyEvents
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class OverlapsOverlappedbyFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
+
+    @Param({"200000"})
+    int nrOfEvents;
 
     @Override
     public void addResources() {
@@ -34,7 +38,7 @@ public class OverlapsOverlappedbyFusionBenchmark extends AbstractSimpleFusionRun
 
     @Override
     public void addEventSenders() {
-        addEventSender(new OverlapsOverlappedbyEventsGenerator(getGeneratorConfiguration()),200000);
+        addEventSender(new OverlapsOverlappedbyEventsGenerator(getGeneratorConfiguration()),nrOfEvents);
     }
 
 

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/RetractFactsFromWmExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/RetractFactsFromWmExpertBenchmark.java
@@ -23,8 +23,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class RetractFactsFromWmExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"1000000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -33,7 +37,7 @@ public class RetractFactsFromWmExpertBenchmark extends AbstractSimpleRuntimeBenc
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new BasicRetractFactsFromWmFactsGenerator(getGeneratorConfiguration()),1000000);
+        addFactsGenerator(new BasicRetractFactsFromWmFactsGenerator(getGeneratorConfiguration()), nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/SimpleDummyFactsMatchRatioExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/SimpleDummyFactsMatchRatioExpertBenchmark.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class SimpleDummyFactsMatchRatioExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
 
-    private int nrOfFacts = 400000;
+    @Param({"400000"})
+    private int nrOfFacts;
 
     @Override
     protected void addResources() {

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/StandardOperatorsExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/StandardOperatorsExpertBenchmark.java
@@ -23,11 +23,15 @@ import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.drools.benchmarks.turtle.runtime.generator.StandardOperatorsFactsGenerator;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 /**
  * Test the standard Expert operators like <,>,<=,>=,&&,||
  */
 public class StandardOperatorsExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"200000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -36,7 +40,7 @@ public class StandardOperatorsExpertBenchmark extends AbstractSimpleRuntimeBench
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new StandardOperatorsFactsGenerator(getGeneratorConfiguration()),200000);
+        addFactsGenerator(new StandardOperatorsFactsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/StartsStartedbyFusionBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/StartsStartedbyFusionBenchmark.java
@@ -24,8 +24,12 @@ import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.drools.benchmarks.turtle.runtime.generator.StartsStartedbyEventsGenerator;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class StartsStartedbyFusionBenchmark extends AbstractSimpleFusionRuntimeBenchmark {
+
+    @Param({"200000"})
+    int nrOfEvents;
 
     @Override
     public void addResources() {
@@ -34,7 +38,7 @@ public class StartsStartedbyFusionBenchmark extends AbstractSimpleFusionRuntimeB
 
     @Override
     public void addEventSenders() {
-        addEventSender(new StartsStartedbyEventsGenerator(getGeneratorConfiguration()),200000);
+        addEventSender(new StartsStartedbyEventsGenerator(getGeneratorConfiguration()),nrOfEvents);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/UpdateFactsInWmExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/UpdateFactsInWmExpertBenchmark.java
@@ -23,8 +23,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class UpdateFactsInWmExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"400000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -33,7 +37,7 @@ public class UpdateFactsInWmExpertBenchmark extends AbstractSimpleRuntimeBenchma
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new BasicUpdateFactsInWmFactsGenerator(getGeneratorConfiguration()),400000);
+        addFactsGenerator(new BasicUpdateFactsInWmFactsGenerator(getGeneratorConfiguration()),nrOfFacts);
     }
 
     @Benchmark

--- a/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/WmManipulationExpertBenchmark.java
+++ b/drools-benchmarks-parent/drools-benchmarks/src/main/java/org/drools/benchmarks/turtle/runtime/WmManipulationExpertBenchmark.java
@@ -23,8 +23,12 @@ import org.drools.benchmarks.turtle.runtime.generator.GeneratorConfiguration;
 import org.drools.benchmarks.turtle.runtime.generator.PlaceHolder;
 import org.kie.api.runtime.KieSession;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 
 public class WmManipulationExpertBenchmark extends AbstractSimpleRuntimeBenchmark {
+
+    @Param({"5000"})
+    int nrOfFacts;
 
     @Override
     protected void addResources() {
@@ -33,7 +37,7 @@ public class WmManipulationExpertBenchmark extends AbstractSimpleRuntimeBenchmar
 
     @Override
     protected void addFactsGenerators() {
-        addFactsGenerator(new BasicWmManipulationFactsGenerator(getGeneratorConfiguration()),5000);
+        addFactsGenerator(new BasicWmManipulationFactsGenerator(getGeneratorConfiguration()), nrOfFacts);
     }
 
     @Benchmark


### PR DESCRIPTION
Similar change as at https://github.com/kiegroup/kie-benchmarks/commit/f4f8944dff46718796d633ed7abe8ffd055c15b7
Adding parameters to have consistent  json report