### PR TITLE
Add maven-dependency-plugin:copy-dependencies

### DIFF
--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -171,6 +171,22 @@
 
   <build>
     <plugins>
+<!--        Copy jar of the drools-core to get the SCM version of the project under test-->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>install</phase>
+                    <goals>
+                        <goal>copy-dependencies</goal>
+                    </goals>
+                    <configuration>
+                        <includeArtifactIds>drools-core</includeArtifactIds>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
When running jmh test it takes the project by version. The version could contain number of commits.
This plugin copies core dependency to allow faster access to the MANIFEST file

/drools-parent/target/dependency/drools-core.jar/META-INF/MANIFEST.MF