### PR TITLE
DROOLS-7456 avoid kie maven plugin to crash on jdk17 project

### DIFF
--- a/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-quick/pom.xml
@@ -47,6 +47,16 @@
                   </transformer>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/drools-benchmarks-parent/drools-benchmarks-reliability/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks-reliability/pom.xml
@@ -98,6 +98,16 @@
                   </transformer>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/drools-benchmarks-parent/drools-benchmarks/pom.xml
+++ b/drools-benchmarks-parent/drools-benchmarks/pom.xml
@@ -42,6 +42,16 @@
                   </transformer>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -191,6 +191,16 @@
                   </transformer>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/pom.xml
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/pom.xml
@@ -90,6 +90,16 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters> <!-- since shading ecj, erase signatures see https://docs.oracle.com/en-us/iaas/data-flow/data-flow-tutorial/develop-apps-locally/create-fat-jars.htm -->
+                <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                      <exclude>META-INF/*.SF</exclude>
+                      <exclude>META-INF/*.DSA</exclude>
+                      <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-7456

**referenced Pull Requests**: 

* requires first a new version of MVEL: https://github.com/mvel/mvel/pull/330
* https://github.com/kiegroup/drools/pull/5267
* https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/48
* https://github.com/kiegroup/kie-benchmarks/pull/245

**Details**:

* drools-ecj is de-shaded, so shading `ECJ` as a dependency the new version containing checksum requires dropping these files from the `ECJ artifact` when building the bundled uber-jar / fat jar creation.