### PR TITLE
bumped up drools version to 8.45.0-SNAPSHOT

### DIFF
--- a/drools-benchmarks-parent/pom.xml
+++ b/drools-benchmarks-parent/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <version.freemaker>2.3.31</version.freemaker>
     <version.jaxb-api>2.0</version.jaxb-api>
-    <version.org.drools>8.44.0-SNAPSHOT</version.org.drools>
+    <version.org.drools>8.45.0-SNAPSHOT</version.org.drools>
   </properties>
 
   <modules>


### PR DESCRIPTION
Generated by build jenkins-KIE-drools-main-tools-kie-benchmarks-update-drools-7: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/main/job/tools/job/kie-benchmarks-update-drools/7/